### PR TITLE
fix(tracking): Reset mouse distance after persist to prevent double-counting

### DIFF
--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -79,12 +79,18 @@ class MouseTracker {
             middleClicks: middleClicks
         )
 
-        // Reset counters (distance accumulates forever, clicks reset after persist)
+        // Reset all counters after persist
+        let persistedDistance = accumulatedDistance
+        let persistedLeft = leftClicks
+        let persistedRight = rightClicks
+        let persistedMiddle = middleClicks
+
+        accumulatedDistance = 0
         leftClicks = 0
         rightClicks = 0
         middleClicks = 0
 
-        print("Mouse data persisted: \(accumulatedDistance)px, L:\(leftClicks) R:\(rightClicks) M:\(middleClicks)")
+        print("Mouse data persisted: \(persistedDistance)px, L:\(persistedLeft) R:\(persistedRight) M:\(persistedMiddle)")
     }
 
     func getCurrentStats() -> (distance: Double, left: Int, right: Int, middle: Int) {


### PR DESCRIPTION
## Summary
- Fixes critical data corruption bug where `accumulatedDistance` was never reset to 0 after persisting to the database, causing the full cumulative distance to be re-added every 30-second persist cycle (resulting in exponentially inflated distance values)
- Fixes debug print statement that read click counters after they were already zeroed, always printing `L:0 R:0 M:0`

## Test plan
- [ ] Launch the app and move the mouse for a few minutes
- [ ] Verify distance values in the popover increase linearly, not exponentially
- [ ] Check the database (`daily_summary.mouse_distance_px`) to confirm values are reasonable
- [ ] Verify click counts still persist correctly after the change
- [ ] Confirm the debug console prints actual persisted values, not zeros

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)