### PR TITLE
fix(events): Use passUnretained to prevent CGEvent memory leak

### DIFF
--- a/InputMetrics/InputMetrics/Services/EventMonitor.swift
+++ b/InputMetrics/InputMetrics/Services/EventMonitor.swift
@@ -45,7 +45,7 @@ class EventMonitor {
             eventsOfInterest: CGEventMask(eventMask),
             callback: { (proxy, type, event, refcon) -> Unmanaged<CGEvent>? in
                 EventMonitor.shared.handleEvent(type: type, event: event)
-                return Unmanaged.passRetained(event)
+                return Unmanaged.passUnretained(event)
             },
             userInfo: nil
         ) else {


### PR DESCRIPTION
## Summary
- Replaces `Unmanaged.passRetained(event)` with `Unmanaged.passUnretained(event)` in the CGEventTap callback
- `passRetained` incremented the retain count on every input event (mouse moves, clicks, keystrokes) without a balancing release, causing continuous memory growth
- For a `.listenOnly` tap, the return value is ignored by the system, so the extra retain was never balanced

## Test plan
- [ ] Launch the app and use it normally for 10+ minutes
- [ ] Monitor memory usage in Activity Monitor — should remain stable instead of growing continuously
- [ ] Verify mouse tracking and keyboard tracking still work correctly

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)