### PR TITLE
fix(data): Flush pending data on app termination

### DIFF
--- a/InputMetrics/InputMetrics/AppDelegate.swift
+++ b/InputMetrics/InputMetrics/AppDelegate.swift
@@ -76,6 +76,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.terminate(nil)
     }
 
+    func applicationWillTerminate(_ notification: Notification) {
+        liveStatsTimer?.invalidate()
+        liveStatsTimer = nil
+
+        MainActor.assumeIsolated {
+            MouseTracker.shared.persistData()
+            KeyboardTracker.shared.persistData()
+            EventMonitor.shared.stop()
+        }
+    }
+
     // MARK: - Live Stats
 
     private func startLiveStatsTimer() {


### PR DESCRIPTION
## Summary
- Adds `applicationWillTerminate` to `AppDelegate` to flush pending tracker data before exit
- Calls `persistData()` on both `MouseTracker` and `KeyboardTracker` synchronously on the main thread
- Invalidates the live stats timer and stops the event monitor cleanly
- Previously, up to 30 seconds of tracked data (mouse distance, clicks, keystrokes) was silently lost on every normal quit

## Test plan
- [ ] Launch the app, move the mouse and type for ~15 seconds (don't wait for the 30s persist cycle)
- [ ] Quit the app via Cmd+Q or the menu bar context menu
- [ ] Relaunch and verify the data from the short session was persisted (visible in today's stats)
- [ ] Verify no crash on quit

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)