### PR TITLE
fix(events): Extract CGEvent values before async dispatch

### DIFF
--- a/InputMetrics/InputMetrics/Services/EventMonitor.swift
+++ b/InputMetrics/InputMetrics/Services/EventMonitor.swift
@@ -71,27 +71,27 @@ class EventMonitor {
     }
 
     private func handleEvent(type: CGEventType, event: CGEvent) {
+        // Extract all values synchronously before the callback returns,
+        // since the CGEvent may be deallocated after the callback exits.
+        let location = event.location
+        let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
+        let flags = event.flags
+
         Task { @MainActor in
             switch type {
             case .mouseMoved:
-                let location = event.location
                 MouseTracker.shared.trackMovement(to: location)
 
             case .leftMouseDown:
-                let location = event.location
                 MouseTracker.shared.trackClick(type: .left, at: location)
 
             case .rightMouseDown:
-                let location = event.location
                 MouseTracker.shared.trackClick(type: .right, at: location)
 
             case .otherMouseDown:
-                let location = event.location
                 MouseTracker.shared.trackClick(type: .middle, at: location)
 
             case .keyDown:
-                let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
-                let flags = event.flags
                 KeyboardTracker.shared.trackKeystroke(keyCode: keyCode, modifierFlags: flags)
 
             default:


### PR DESCRIPTION
## Summary
- Extracts `location`, `keyCode`, and `flags` from `CGEvent` synchronously in the event tap callback, before dispatching to the async `Task`
- The `CGEvent` is owned by the system and may be deallocated after the callback returns — accessing its properties inside the async `Task` could read freed memory

## Test plan
- [ ] Launch the app and verify mouse tracking works (distance accumulates)
- [ ] Verify click tracking works (left, right, middle clicks counted)
- [ ] Verify keyboard tracking works (keystrokes counted, heatmap populated)
- [ ] Run under Address Sanitizer if possible to confirm no use-after-free

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)