### PR TITLE
style(settings): Remove gradient on gear icon

### DIFF
--- a/InputMetrics/InputMetrics/Views/SettingsView.swift
+++ b/InputMetrics/InputMetrics/Views/SettingsView.swift
@@ -15,7 +15,7 @@ struct SettingsView: View {
                     VStack(spacing: 8) {
                         Image(systemName: "gearshape.fill")
                             .font(.system(size: 48))
-                            .foregroundStyle(.blue.gradient)
+                            .foregroundStyle(.blue)
 
                         Text("Settings")
                             .font(.title.bold())


### PR DESCRIPTION
## Summary
- Replaces `.foregroundStyle(.blue.gradient)` with `.foregroundStyle(.blue)` on the settings gear icon

## Test plan
- [ ] Open Settings and verify the gear icon renders with a flat blue color

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)