### PR TITLE
fix(db): Remove redundant indexes on primary key columns

### DIFF
--- a/InputMetrics/InputMetrics/Services/DatabaseManager.swift
+++ b/InputMetrics/InputMetrics/Services/DatabaseManager.swift
@@ -78,10 +78,6 @@ final class DatabaseManager: @unchecked Sendable {
                 t.column("keystrokes", .integer).defaults(to: 0)
                 t.primaryKey(["date", "hour"])
             }
-
-            // Create indexes
-            try db.create(index: "idx_daily_date", on: "daily_summary", columns: ["date"])
-            try db.create(index: "idx_hourly_date", on: "hourly_summary", columns: ["date"])
         }
 
         return migrator


### PR DESCRIPTION
## Summary
- Removes `idx_daily_date` index on `daily_summary.date` — already the table's primary key
- Removes `idx_hourly_date` index on `hourly_summary.date` — first column of the composite primary key `(date, hour)`, so SQLite's PK index already covers date-only lookups

## Test plan
- [ ] Launch the app on a fresh install and verify the database initializes without errors
- [ ] Verify daily summary reads/writes still work correctly
- [ ] Note: existing databases keep the old indexes (migration is already applied) — this only affects new installs

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)