### PR TITLE
fix(ui): Surface errors to users instead of silent failures

### DIFF
--- a/InputMetrics/InputMetrics/AppDelegate.swift
+++ b/InputMetrics/InputMetrics/AppDelegate.swift
@@ -10,6 +10,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Initialize database
         _ = DatabaseManager.shared
 
+        if !DatabaseManager.shared.isReady {
+            let alert = NSAlert()
+            alert.messageText = "Database Error"
+            alert.informativeText = DatabaseManager.shared.initializationError
+                ?? "Failed to initialize the database."
+            alert.alertStyle = .critical
+            alert.addButton(withTitle: "Quit")
+            alert.runModal()
+            NSApp.terminate(nil)
+            return
+        }
+
         // Create menu bar icon
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 

--- a/InputMetrics/InputMetrics/Services/DatabaseManager.swift
+++ b/InputMetrics/InputMetrics/Services/DatabaseManager.swift
@@ -6,6 +6,9 @@ final class DatabaseManager: @unchecked Sendable {
 
     private var dbQueue: DatabaseQueue?
     private let dbQueue_serial = DispatchQueue(label: "com.inputmetrics.database", qos: .userInitiated)
+    private(set) var initializationError: String?
+
+    var isReady: Bool { dbQueue != nil }
 
     private init() {
         setupDatabase()
@@ -32,6 +35,7 @@ final class DatabaseManager: @unchecked Sendable {
 
             print("Database initialized successfully")
         } catch {
+            initializationError = "Database setup failed: \(error.localizedDescription)"
             print("Database setup error: \(error)")
         }
     }

--- a/InputMetrics/InputMetrics/Views/SettingsView.swift
+++ b/InputMetrics/InputMetrics/Views/SettingsView.swift
@@ -1,11 +1,36 @@
 import SwiftUI
 import LaunchAtLogin
 
+enum ExportResult {
+    case success(String)
+    case failure(String)
+
+    var message: String {
+        switch self {
+        case .success(let msg), .failure(let msg): return msg
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .success: return "checkmark.circle.fill"
+        case .failure: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .success: return .green
+        case .failure: return .red
+        }
+    }
+}
+
 struct SettingsView: View {
     @ObservedObject private var preferences = UserPreferences.shared
     @State private var showResetConfirmation = false
-    @State private var exportMessage: String?
-    @State private var showExportSuccess = false
+    @State private var exportResult: ExportResult?
+    @State private var showExportToast = false
 
     var body: some View {
         ZStack {
@@ -162,16 +187,15 @@ struct SettingsView: View {
                 .padding(.horizontal, 32)
             }
 
-            // Success notification
-            if showExportSuccess, let message = exportMessage {
+            if showExportToast, let result = exportResult {
                 VStack {
                     Spacer()
 
                     HStack(spacing: 12) {
-                        Image(systemName: message.contains("success") ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                            .foregroundStyle(message.contains("success") ? .green : .red)
+                        Image(systemName: result.icon)
+                            .foregroundStyle(result.color)
 
-                        Text(message)
+                        Text(result.message)
                             .font(.subheadline)
                             .foregroundStyle(.primary)
                     }
@@ -193,19 +217,19 @@ struct SettingsView: View {
         } message: {
             Text("This will permanently delete all tracking data. This action cannot be undone.")
         }
-        .onChange(of: exportMessage) { oldValue, newValue in
+        .onChange(of: exportResult?.message) { oldValue, newValue in
             if newValue != nil {
                 withAnimation(.spring(response: 0.4, dampingFraction: 0.7)) {
-                    showExportSuccess = true
+                    showExportToast = true
                 }
 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                     withAnimation {
-                        showExportSuccess = false
+                        showExportToast = false
                     }
 
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        exportMessage = nil
+                        exportResult = nil
                     }
                 }
             }
@@ -223,9 +247,9 @@ struct SettingsView: View {
                 do {
                     let csvContent = generateCSV()
                     try csvContent.write(to: url, atomically: true, encoding: .utf8)
-                    exportMessage = "Data exported successfully to \(url.lastPathComponent)"
+                    exportResult = .success("Data exported to \(url.lastPathComponent)")
                 } catch {
-                    exportMessage = "Export failed: \(error.localizedDescription)"
+                    exportResult = .failure("Export failed: \(error.localizedDescription)")
                 }
             }
         }
@@ -271,7 +295,7 @@ struct SettingsView: View {
 
     private func resetData() {
         DatabaseManager.shared.resetAllData()
-        exportMessage = "All data has been reset"
+        exportResult = .success("All data has been reset")
     }
 }
 


### PR DESCRIPTION
## Summary
- **DatabaseManager**: Add `initializationError` and `isReady` properties to expose DB init status
- **AppDelegate**: Show critical `NSAlert` with error details and quit button on DB failure at launch
- **SettingsView**: Replace fragile `message.contains("success")` string matching with typed `ExportResult` enum for toast icon/color

## Test plan
- [ ] Force a DB error (e.g. invalid path) → alert shown on launch with error details
- [ ] Normal launch → no alert
- [ ] Export success → green checkmark toast
- [ ] Export failure → red warning toast
- [ ] Reset data → green checkmark toast

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)