### PR TITLE
fix(tracker): Cast screen ID to NSNumber before stringValue

### DIFF
--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -131,7 +131,7 @@ class MouseTracker {
         // Find which screen contains this point
         for screen in NSScreen.screens {
             if screen.frame.contains(point) {
-                return screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? String ?? "primary"
+                return (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.stringValue ?? "primary"
             }
         }
         return "primary"


### PR DESCRIPTION
## Summary
- Fix screen ID retrieval by casting `NSScreenNumber` to `NSNumber` first, then calling `stringValue` — the value is a `CGDirectDisplayID` (UInt32), not a `String`, so `as? String` always returned `nil` and fell back to `"primary"`

## Test plan
- [ ] Verify screen IDs are correctly identified on multi-monitor setups
- [ ] Confirm single-monitor still returns valid screen ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)