### PR TITLE
fix(tracker): Convert CG to AppKit coordinates for heatmap

### DIFF
--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -98,9 +98,12 @@ class MouseTracker {
     }
 
     private func bucketForPoint(_ point: CGPoint) -> (x: Int, y: Int) {
-        // Get all screens and calculate combined bounds
         let screens = NSScreen.screens
         guard !screens.isEmpty else { return (0, 0) }
+
+        // Convert CG Y (origin bottom-left) to AppKit Y (origin top-left)
+        let primaryHeight = NSScreen.screens[0].frame.height
+        let appKitY = primaryHeight - point.y
 
         var minX = CGFloat.infinity
         var minY = CGFloat.infinity
@@ -120,7 +123,7 @@ class MouseTracker {
 
         // Normalize to 50x50 grid
         let normalizedX = (point.x - minX) / width
-        let normalizedY = (point.y - minY) / height
+        let normalizedY = (appKitY - minY) / height
         let bucketX = min(49, max(0, Int(normalizedX * 50)))
         let bucketY = min(49, max(0, Int(normalizedY * 50)))
 


### PR DESCRIPTION
## Summary
- Fix heatmap Y-axis inversion by converting CGEvent coordinates (origin bottom-left) to AppKit coordinates (origin top-left) before bucketing
- Without this fix, heatmap data was vertically flipped relative to actual cursor position

## Test plan
- [ ] Verify heatmap accurately reflects cursor positions (top of screen shows at top of heatmap)
- [ ] Test on multi-monitor setups with different screen heights

🤖 Generated with [Claude Code](https://claude.com/claude-code)