### PR TITLE
fix(dates): Set en_US_POSIX locale on all DateFormatters

### DIFF
--- a/InputMetrics/InputMetrics/AppDelegate.swift
+++ b/InputMetrics/InputMetrics/AppDelegate.swift
@@ -120,6 +120,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let keyboardStats = KeyboardTracker.shared.getCurrentKeystrokes()
 
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         let today = formatter.string(from: Date())
 

--- a/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
+++ b/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
@@ -56,6 +56,7 @@ class KeyboardTracker {
 
     private func getTodayString() -> String {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: Date())
     }

--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -139,6 +139,7 @@ class MouseTracker {
 
     private func getTodayString() -> String {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: Date())
     }

--- a/InputMetrics/InputMetrics/Views/HeatmapView.swift
+++ b/InputMetrics/InputMetrics/Views/HeatmapView.swift
@@ -42,6 +42,7 @@ struct HeatmapView: View {
 
     private func loadHeatmapData() {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         let today = formatter.string(from: Date())
 

--- a/InputMetrics/InputMetrics/Views/KeyboardStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/KeyboardStatsView.swift
@@ -61,6 +61,7 @@ struct KeyboardStatsView: View {
         let calendar = Calendar.current
         let today = Date()
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
 
         let daysBack: Int
@@ -80,6 +81,7 @@ struct KeyboardStatsView: View {
 
     private func loadKeyboardData() {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         let today = formatter.string(from: Date())
 

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -372,6 +372,7 @@ struct MenuBarView: View {
         let calendar = Calendar.current
         let today = Date()
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
 
         guard let startDate = calendar.date(byAdding: .day, value: -6, to: today) else { return }
@@ -427,6 +428,7 @@ struct MenuBarView: View {
 
     private func shortDay(from dateString: String) -> String {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         guard let date = formatter.date(from: dateString) else { return "" }
 
@@ -436,6 +438,7 @@ struct MenuBarView: View {
 
     private func getTodayString() -> String {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: Date())
     }

--- a/InputMetrics/InputMetrics/Views/MouseStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/MouseStatsView.swift
@@ -83,6 +83,7 @@ struct MouseStatsView: View {
         let calendar = Calendar.current
         let today = Date()
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
 
         let daysBack: Int
@@ -104,6 +105,7 @@ struct MouseStatsView: View {
         // TODO: Add a method to get all-time totals from database
         // For now, just get today's data
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         let today = formatter.string(from: Date())
 


### PR DESCRIPTION
## Summary
- Set `en_US_POSIX` locale on all `DateFormatter` instances using fixed-format date strings (`yyyy-MM-dd`)
- Prevents date parsing/formatting failures on devices with non-Gregorian calendars or locales that override date format components
- Affects AppDelegate, KeyboardTracker, MouseTracker, HeatmapView, KeyboardStatsView, MenuBarView, and MouseStatsView

## Test plan
- [ ] Verify date strings remain in `yyyy-MM-dd` format regardless of system locale
- [ ] Test with non-Gregorian calendar system locale (e.g., Japanese, Buddhist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)