### PR TITLE
fix(heatmap): Add negative bounds check for bucket indices

### DIFF
--- a/InputMetrics/InputMetrics/Views/HeatmapView.swift
+++ b/InputMetrics/InputMetrics/Views/HeatmapView.swift
@@ -52,7 +52,7 @@ struct HeatmapView: View {
 
         // Fill in the click counts
         for entry in entries {
-            guard entry.bucketX < Constants.heatmapGridSize && entry.bucketY < Constants.heatmapGridSize else { continue }
+            guard entry.bucketX >= 0 && entry.bucketY >= 0 && entry.bucketX < Constants.heatmapGridSize && entry.bucketY < Constants.heatmapGridSize else { continue }
             grid[entry.bucketY][entry.bucketX] += entry.clickCount
         }
 

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -389,7 +389,7 @@ struct MenuBarView: View {
         var grid = Array(repeating: Array(repeating: 0, count: 50), count: 50)
 
         for entry in entries {
-            guard entry.bucketX < 50 && entry.bucketY < 50 else { continue }
+            guard entry.bucketX >= 0 && entry.bucketY >= 0 && entry.bucketX < 50 && entry.bucketY < 50 else { continue }
             grid[entry.bucketY][entry.bucketX] += entry.clickCount
         }
 


### PR DESCRIPTION
## Summary
- Add `>= 0` guard checks for `bucketX` and `bucketY` in HeatmapView and MenuBarView
- Negative bucket indices could cause array-out-of-bounds crashes since only upper bounds were checked

Closes #32

## Test plan
- [ ] Verify heatmap renders without crashes when edge-case coordinates produce negative buckets
- [ ] Confirm normal heatmap rendering is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)