### PR TITLE
fix(keyboard): Filter modifier flags to meaningful keys only

### DIFF
--- a/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
+++ b/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
@@ -17,7 +17,8 @@ class KeyboardTracker {
         totalKeystrokes += 1
 
         let today = getTodayString()
-        let modifierInt = Int(modifierFlags.rawValue)
+        let meaningfulFlags = modifierFlags.intersection([.maskShift, .maskControl, .maskAlternate, .maskCommand])
+        let modifierInt = Int(meaningfulFlags.rawValue)
 
         // Update keyboard heatmap in database
         DatabaseManager.shared.updateKeyboard(


### PR DESCRIPTION
## Summary
- Intersect modifier flags with only meaningful modifiers (Shift, Control, Option, Command) before storing
- The full `rawValue` bitmask includes device-dependent bits that fragment heatmap data into duplicate entries for the same logical key combination

Closes #36

## Test plan
- [ ] Verify keyboard heatmap correctly groups keys by modifier (e.g., Shift+A entries are consolidated)
- [ ] Confirm modifier display still shows correct modifiers in stats views

🤖 Generated with [Claude Code](https://claude.com/claude-code)