### PR TITLE
fix(events): Re-enable event tap on system timeout or user disable

### DIFF
--- a/InputMetrics/InputMetrics/Services/EventMonitor.swift
+++ b/InputMetrics/InputMetrics/Services/EventMonitor.swift
@@ -44,6 +44,10 @@ class EventMonitor {
             options: .listenOnly,
             eventsOfInterest: CGEventMask(eventMask),
             callback: { (proxy, type, event, refcon) -> Unmanaged<CGEvent>? in
+                if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                    CGEvent.tapEnable(tap: proxy, enable: true)
+                    return Unmanaged.passUnretained(event)
+                }
                 EventMonitor.shared.handleEvent(type: type, event: event)
                 return Unmanaged.passUnretained(event)
             },


### PR DESCRIPTION
## Summary
- Handle `tapDisabledByTimeout` and `tapDisabledByUserInput` events by re-enabling the event tap
- Without this, the event tap silently stops receiving events after macOS disables it, causing all tracking to halt until app restart

Closes #25

## Test plan
- [ ] Verify event tracking resumes after system temporarily disables the tap
- [ ] Confirm normal event handling is not affected by the early return for disable events

🤖 Generated with [Claude Code](https://claude.com/claude-code)