### PR TITLE
fix(ui): Respect user's distance unit preference in all views

### DIFF
--- a/InputMetrics/InputMetrics/AppDelegate.swift
+++ b/InputMetrics/InputMetrics/AppDelegate.swift
@@ -139,11 +139,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         button.title = " \(distanceText) · \(keystrokesText)"
     }
 
-    private func formatDistance(_ meters: Double) -> String {
-        if meters >= 1000 {
-            return String(format: "%.1fkm", meters / 1000)
+    @MainActor private func formatDistance(_ meters: Double) -> String {
+        if UserPreferences.shared.distanceUnit == .imperial {
+            let feet = meters / Constants.metersPerFoot
+            if feet >= Constants.feetPerMile {
+                return String(format: "%.1fmi", feet / Constants.feetPerMile)
+            } else {
+                return String(format: "%.0fft", feet)
+            }
         } else {
-            return String(format: "%.0fm", meters)
+            if meters >= 1000 {
+                return String(format: "%.1fkm", meters / 1000)
+            } else {
+                return String(format: "%.0fm", meters)
+            }
         }
     }
 

--- a/InputMetrics/InputMetrics/Views/ChartView.swift
+++ b/InputMetrics/InputMetrics/Views/ChartView.swift
@@ -7,6 +7,7 @@ enum ChartMetric {
 }
 
 struct ChartView: View {
+    @ObservedObject private var preferences = UserPreferences.shared
     let data: [DailySummary]
     let range: TimeRange
     var metric: ChartMetric = .distance
@@ -51,7 +52,7 @@ struct ChartView: View {
     private var yAxisLabel: String {
         switch metric {
         case .distance:
-            return "Distance (km)"
+            return preferences.distanceUnit == .metric ? "Distance (km)" : "Distance (mi)"
         case .keystrokes:
             return "Keystrokes"
         }
@@ -71,7 +72,12 @@ struct ChartView: View {
     private func metricValue(for item: DailySummary) -> Double {
         switch metric {
         case .distance:
-            return DistanceConverter.metersToKilometers(DistanceConverter.pixelsToMeters(item.mouseDistancePx))
+            let meters = DistanceConverter.pixelsToMeters(item.mouseDistancePx)
+            if preferences.distanceUnit == .metric {
+                return DistanceConverter.metersToKilometers(meters)
+            } else {
+                return DistanceConverter.feetToMiles(DistanceConverter.metersToFeet(meters))
+            }
         case .keystrokes:
             return Double(item.keystrokes)
         }

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -153,12 +153,12 @@ struct MenuBarView: View {
                     Chart(chartData.suffix(7), id: \.date) { item in
                         BarMark(
                             x: .value("Day", shortDay(from: item.date)),
-                            y: .value("Distance", DistanceConverter.pixelsToMeters(item.mouseDistancePx) * 3.28084)
+                            y: .value("Distance", chartDistance(item.mouseDistancePx))
                         )
                         .foregroundStyle(.blue.gradient)
                     }
                     .frame(height: 150)
-                    .chartYAxisLabel("ft")
+                    .chartYAxisLabel(preferences.distanceUnit == .metric ? "km" : "mi")
                     .padding(.horizontal)
                 } else {
                     Text("No data yet")
@@ -424,6 +424,16 @@ struct MenuBarView: View {
         allTimeDistance = totalDistance
         allTimeClicks = totalClicks
         allTimeKeystrokes = totalKeys
+    }
+
+    private func chartDistance(_ pixels: Double) -> Double {
+        let meters = DistanceConverter.pixelsToMeters(pixels)
+        if preferences.distanceUnit == .metric {
+            return DistanceConverter.metersToKilometers(meters)
+        } else {
+            let feet = DistanceConverter.metersToFeet(meters)
+            return DistanceConverter.feetToMiles(feet)
+        }
     }
 
     private func shortDay(from dateString: String) -> String {


### PR DESCRIPTION
## Summary
- Fix MenuBarView chart to use user's unit preference instead of hardcoded feet conversion
- Fix ChartView to show km or mi based on preference instead of always km
- Fix AppDelegate.formatDistance() to format in imperial when selected

Closes #28

## Test plan
- [ ] Toggle distance unit in Settings and verify MenuBarView chart updates Y-axis label and values
- [ ] Verify ChartView shows correct unit label and values for both metric and imperial
- [ ] Verify menu bar tooltip/status text uses correct unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)