### PR TITLE
fix(data): Clear in-memory trackers when resetting data

### DIFF
--- a/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
+++ b/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
@@ -51,6 +51,10 @@ class KeyboardTracker {
         print("Keyboard data persisted: \(count) keystrokes")
     }
 
+    func reset() {
+        totalKeystrokes = 0
+    }
+
     func getCurrentKeystrokes() -> Int {
         return totalKeystrokes
     }

--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -93,6 +93,14 @@ class MouseTracker {
         print("Mouse data persisted: \(persistedDistance)px, L:\(persistedLeft) R:\(persistedRight) M:\(persistedMiddle)")
     }
 
+    func reset() {
+        accumulatedDistance = 0
+        leftClicks = 0
+        rightClicks = 0
+        middleClicks = 0
+        lastPoint = nil
+    }
+
     func getCurrentStats() -> (distance: Double, left: Int, right: Int, middle: Int) {
         return (accumulatedDistance, leftClicks, rightClicks, middleClicks)
     }

--- a/InputMetrics/InputMetrics/Views/SettingsView.swift
+++ b/InputMetrics/InputMetrics/Views/SettingsView.swift
@@ -317,6 +317,8 @@ struct SettingsView: View {
 
     private func resetData() {
         DatabaseManager.shared.resetAllData()
+        MouseTracker.shared.reset()
+        KeyboardTracker.shared.reset()
         exportResult = .success("All data has been reset")
     }
 }


### PR DESCRIPTION
## Summary
- Add `reset()` methods to MouseTracker and KeyboardTracker to clear in-memory state
- Call both reset methods from SettingsView.resetData() after clearing the database
- Prevents in-memory counters from being written back on the next persist cycle, partially restoring deleted data

Closes #30

## Test plan
- [ ] Reset data in Settings, wait 30+ seconds, verify counters stay at zero
- [ ] Confirm tracking resumes correctly after reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)