### PR TITLE
fix(settings): Update to macOS 13+ System Settings URL scheme

### DIFF
--- a/InputMetrics/InputMetrics/Services/EventMonitor.swift
+++ b/InputMetrics/InputMetrics/Services/EventMonitor.swift
@@ -26,7 +26,8 @@ class EventMonitor {
 
                 let response = alert.runModal()
                 if response == .alertFirstButtonReturn {
-                    NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
+                    guard let url = URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility") else { return }
+                    NSWorkspace.shared.open(url)
                 }
             }
             return


### PR DESCRIPTION
## Summary
- Replace deprecated `x-apple.systempreferences:com.apple.preference.security` URL with macOS 13+ `com.apple.settings.PrivacySecurity.extension` scheme
- Replace force-unwrap with `guard let` for safe URL construction

Closes #34

## Test plan
- [ ] Click the accessibility prompt and verify System Settings opens to Privacy & Security
- [ ] Verify no crash if URL construction were to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)