### PR TITLE
fix(ui): Use composite id for ForEach to prevent key collisions

### DIFF
--- a/InputMetrics/InputMetrics/Models/KeyboardEntry.swift
+++ b/InputMetrics/InputMetrics/Models/KeyboardEntry.swift
@@ -16,6 +16,10 @@ struct KeyboardEntry: Codable, FetchableRecord, PersistableRecord {
         case count
     }
 
+    var compositeId: String {
+        "\(keyCode)-\(modifierFlags)"
+    }
+
     enum Columns {
         static let date = Column(CodingKeys.date)
         static let keyCode = Column(CodingKeys.keyCode)

--- a/InputMetrics/InputMetrics/Views/KeyboardStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/KeyboardStatsView.swift
@@ -39,8 +39,8 @@ struct KeyboardStatsView: View {
                     .font(.headline)
 
                 HStack(spacing: 12) {
-                    ForEach(topKeys(), id: \.0) { key, count in
-                        Text("\(key) (\(count))")
+                    ForEach(topKeys(), id: \.id) { entry in
+                        Text("\(entry.name) (\(entry.count))")
                             .font(.caption)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 4)
@@ -88,9 +88,9 @@ struct KeyboardStatsView: View {
         keyboardEntries = DatabaseManager.shared.getKeyboardEntries(date: today)
     }
 
-    private func topKeys() -> [(String, Int)] {
+    private func topKeys() -> [(id: String, name: String, count: Int)] {
         let sorted = keyboardEntries.sorted { $0.count > $1.count }
-        return Array(sorted.prefix(5)).map { (KeyCodeMapping.keyName(for: $0.keyCode), $0.count) }
+        return Array(sorted.prefix(5)).map { ($0.compositeId, KeyCodeMapping.keyName(for: $0.keyCode), $0.count) }
     }
 }
 

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -254,7 +254,7 @@ struct MenuBarView: View {
                 if !keyboardEntries.isEmpty {
                     let topKeys = keyboardEntries.sorted { $0.count > $1.count }.prefix(5)
                     HStack(spacing: 8) {
-                        ForEach(Array(topKeys), id: \.keyCode) { entry in
+                        ForEach(Array(topKeys), id: \.compositeId) { entry in
                             VStack(spacing: 4) {
                                 Text(KeyCodeMapping.keyName(for: entry.keyCode))
                                     .font(.caption.bold())


### PR DESCRIPTION
## Summary
- Add `compositeId` computed property to KeyboardEntry combining keyCode and modifierFlags
- Fix MenuBarView ForEach to use `compositeId` instead of `keyCode` alone
- Fix KeyboardStatsView ForEach to carry composite id through the tuple, preventing collisions for keys with the same display name (e.g., L/R Shift)

Closes #35

## Test plan
- [ ] Verify top keys list renders correctly when keys share same keyCode but different modifiers
- [ ] Verify no duplicate/missing rows in keyboard stats view

🤖 Generated with [Claude Code](https://claude.com/claude-code)