### PR TITLE
fix(a11y): Add VoiceOver labels to heatmaps and icon buttons

### DIFF
--- a/InputMetrics/InputMetrics/Views/HeatmapView.swift
+++ b/InputMetrics/InputMetrics/Views/HeatmapView.swift
@@ -33,6 +33,8 @@ struct HeatmapView: View {
                 }
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Mouse click heatmap")
         .background(Color.black.opacity(0.1))
         .cornerRadius(8)
         .onAppear {

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -33,6 +33,7 @@ struct MenuBarView: View {
                     Image(systemName: "gearshape")
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Settings")
 
                 Spacer()
 
@@ -481,6 +482,8 @@ struct HeatmapCanvas: View {
                 }
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Mouse click heatmap")
         .background(Color.black.opacity(0.05))
         .cornerRadius(8)
     }


### PR DESCRIPTION
## Summary
- Add `.accessibilityElement(children: .ignore)` and `.accessibilityLabel` to Canvas-based heatmaps in HeatmapView and MenuBarView
- Add `.accessibilityLabel("Settings")` to gear icon button in MenuBarView

Closes #42

## Test plan
- [ ] Enable VoiceOver and verify heatmaps are announced as "Mouse click heatmap"
- [ ] Verify gear icon button is announced as "Settings"

🤖 Generated with [Claude Code](https://claude.com/claude-code)