### PR TITLE
fix(chart): Fix date formatting on chart x-axis

### DIFF
--- a/InputMetrics/InputMetrics/Views/ChartView.swift
+++ b/InputMetrics/InputMetrics/Views/ChartView.swift
@@ -25,17 +25,12 @@ struct ChartView: View {
             } else {
                 Chart(data, id: \.date) { item in
                     BarMark(
-                        x: .value("Date", item.date),
+                        x: .value("Date", formatLabel(from: item.date)),
                         y: .value("Value", metricValue(for: item))
                     )
                     .foregroundStyle(Color.blue)
                 }
                 .chartYAxisLabel(yAxisLabel)
-                .chartXAxis {
-                    AxisMarks(values: .automatic) { value in
-                        AxisValueLabel(format: xAxisFormat)
-                    }
-                }
             }
         }
     }
@@ -58,15 +53,22 @@ struct ChartView: View {
         }
     }
 
-    private var xAxisFormat: Date.FormatStyle {
+    private func formatLabel(from dateString: String) -> String {
+        let parser = DateFormatter()
+        parser.locale = Locale(identifier: "en_US_POSIX")
+        parser.dateFormat = "yyyy-MM-dd"
+        guard let date = parser.date(from: dateString) else { return dateString }
+
+        let display = DateFormatter()
         switch range {
         case .week:
-            return .dateTime.weekday(.abbreviated)
+            display.dateFormat = "EEE"
         case .month:
-            return .dateTime.day()
+            display.dateFormat = "d"
         case .year:
-            return .dateTime.month().day()
+            display.dateFormat = "MMM d"
         }
+        return display.string(from: date)
     }
 
     private func metricValue(for item: DailySummary) -> Double {


### PR DESCRIPTION
## Summary
- Remove unused `xAxisFormat` (Date.FormatStyle) that never applied to String x-axis values
- Add `formatLabel(from:)` that parses date strings and formats based on time range (weekday for week, day number for month, month+day for year)
- Pre-format labels before passing to BarMark so they display correctly

Closes #2

## Test plan
- [ ] Verify chart x-axis shows abbreviated weekdays in week view
- [ ] Verify month view shows day numbers, year view shows month+day
- [ ] Confirm MouseStatsView and KeyboardStatsView charts still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)