### PR TITLE
fix(stats): Aggregate all daily summaries for all-time mouse stats

### DIFF
--- a/InputMetrics/InputMetrics/Views/MouseStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/MouseStatsView.swift
@@ -102,14 +102,30 @@ struct MouseStatsView: View {
     }
 
     private func loadAllTimeStats() {
-        // TODO: Add a method to get all-time totals from database
-        // For now, just get today's data
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        let today = formatter.string(from: Date())
+        let allSummaries = DatabaseManager.shared.getAllDailySummaries()
 
-        allTimeStats = DatabaseManager.shared.getDailySummary(date: today)
+        var totalDistance: Double = 0
+        var totalClicksLeft: Int = 0
+        var totalClicksRight: Int = 0
+        var totalClicksMiddle: Int = 0
+        var totalKeystrokes: Int = 0
+
+        for summary in allSummaries {
+            totalDistance += summary.mouseDistancePx
+            totalClicksLeft += summary.mouseClicksLeft
+            totalClicksRight += summary.mouseClicksRight
+            totalClicksMiddle += summary.mouseClicksMiddle
+            totalKeystrokes += summary.keystrokes
+        }
+
+        allTimeStats = DailySummary(
+            date: "",
+            mouseDistancePx: totalDistance,
+            mouseClicksLeft: totalClicksLeft,
+            mouseClicksRight: totalClicksRight,
+            mouseClicksMiddle: totalClicksMiddle,
+            keystrokes: totalKeystrokes
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace single-day fetch in `MouseStatsView.loadAllTimeStats()` with aggregation across all daily summaries
- Previously only fetched today's data but labeled it "All-Time Stats"
- Now sums mouseDistancePx, clicks, and keystrokes across all rows, matching MenuBarView behavior

Closes #1

## Test plan
- [ ] Verify all-time stats show cumulative totals across multiple days of data
- [ ] Confirm values match what MenuBarView reports for all-time stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)