### PR TITLE
perf(keyboard): Batch keyboard heatmap DB writes

### DIFF
--- a/InputMetrics/InputMetrics/Services/DatabaseManager.swift
+++ b/InputMetrics/InputMetrics/Services/DatabaseManager.swift
@@ -236,6 +236,37 @@ final class DatabaseManager: @unchecked Sendable {
         }
     }
 
+    func updateKeyboardBatch(date: String, entries: [(keyCode: Int, modifierFlags: Int, count: Int)]) {
+        guard let db = dbQueue else { return }
+
+        dbQueue_serial.async {
+            do {
+                try db.write { db in
+                    for entry in entries {
+                        if var existing = try KeyboardEntry
+                            .filter(KeyboardEntry.Columns.date == date)
+                            .filter(KeyboardEntry.Columns.keyCode == entry.keyCode)
+                            .filter(KeyboardEntry.Columns.modifierFlags == entry.modifierFlags)
+                            .fetchOne(db) {
+                            existing.count += entry.count
+                            try existing.update(db)
+                        } else {
+                            let newEntry = KeyboardEntry(
+                                date: date,
+                                keyCode: entry.keyCode,
+                                modifierFlags: entry.modifierFlags,
+                                count: entry.count
+                            )
+                            try newEntry.insert(db)
+                        }
+                    }
+                }
+            } catch {
+                print("Error updating keyboard batch: \(error)")
+            }
+        }
+    }
+
     func getKeyboardEntries(date: String) -> [KeyboardEntry] {
         guard let db = dbQueue else { return [] }
 

--- a/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
+++ b/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
@@ -9,6 +9,13 @@ class KeyboardTracker {
     private var persistTimer: Timer?
     private let persistInterval: TimeInterval = 30.0
 
+    private struct HeatmapKey: Hashable {
+        let keyCode: Int
+        let modifierFlags: Int
+    }
+
+    private var heatmapBuffer: [HeatmapKey: Int] = [:]
+
     private init() {
         setupPersistTimer()
     }
@@ -16,16 +23,11 @@ class KeyboardTracker {
     func trackKeystroke(keyCode: Int, modifierFlags: CGEventFlags) {
         totalKeystrokes += 1
 
-        let today = getTodayString()
         let meaningfulFlags = modifierFlags.intersection([.maskShift, .maskControl, .maskAlternate, .maskCommand])
         let modifierInt = Int(meaningfulFlags.rawValue)
 
-        // Update keyboard heatmap in database
-        DatabaseManager.shared.updateKeyboard(
-            date: today,
-            keyCode: keyCode,
-            modifierFlags: modifierInt
-        )
+        let key = HeatmapKey(keyCode: keyCode, modifierFlags: modifierInt)
+        heatmapBuffer[key, default: 0] += 1
     }
 
     private func setupPersistTimer() {
@@ -44,15 +46,27 @@ class KeyboardTracker {
             keystrokes: totalKeystrokes
         )
 
-        // Reset counter
+        let bufferedEntries = heatmapBuffer
+        heatmapBuffer.removeAll(keepingCapacity: true)
+
+        if !bufferedEntries.isEmpty {
+            DatabaseManager.shared.updateKeyboardBatch(
+                date: today,
+                entries: bufferedEntries.map { (key, count) in
+                    (keyCode: key.keyCode, modifierFlags: key.modifierFlags, count: count)
+                }
+            )
+        }
+
         let count = totalKeystrokes
         totalKeystrokes = 0
 
-        print("Keyboard data persisted: \(count) keystrokes")
+        print("Keyboard data persisted: \(count) keystrokes, \(bufferedEntries.count) unique keys")
     }
 
     func reset() {
         totalKeystrokes = 0
+        heatmapBuffer.removeAll()
     }
 
     func getCurrentKeystrokes() -> Int {


### PR DESCRIPTION
## Summary
- Accumulate key press counts in an in-memory dictionary instead of writing to the database on every key press
- Flush the buffered heatmap entries to DB on the existing 30-second persist timer via a new updateKeyboardBatch method
- All buffered entries are written in a single DB transaction, reducing I/O from N writes per interval to 1
- Clear the buffer on reset() to keep state consistent

Closes #5

## Test plan
- Type at high speed and verify heatmap data still appears correctly in the keyboard heatmap view
- Confirm the 30-second persist timer logs both keystroke count and unique key count
- Verify that after calling reset(), the heatmap buffer is empty
- Confirm no data loss across date boundaries (buffer is flushed with the date at persist time)
- Monitor database I/O to confirm writes are batched rather than per-keypress

🤖 Generated with [Claude Code](https://claude.com/claude-code)