### PR TITLE
perf(stats): Move live stats DB read off main thread

### DIFF
--- a/InputMetrics/InputMetrics/AppDelegate.swift
+++ b/InputMetrics/InputMetrics/AppDelegate.swift
@@ -125,19 +125,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         formatter.dateFormat = "yyyy-MM-dd"
         let today = formatter.string(from: Date())
 
-        var totalDistance = mouseStats.distance
-        var totalKeystrokes = keyboardStats
+        Task.detached { [weak self] in
+            let summary = DatabaseManager.shared.getDailySummary(date: today)
 
-        if let summary = DatabaseManager.shared.getDailySummary(date: today) {
-            totalDistance += summary.mouseDistancePx
-            totalKeystrokes += summary.keystrokes
+            await MainActor.run {
+                guard let self else { return }
+
+                var totalDistance = mouseStats.distance
+                var totalKeystrokes = keyboardStats
+
+                if let summary {
+                    totalDistance += summary.mouseDistancePx
+                    totalKeystrokes += summary.keystrokes
+                }
+
+                let distanceMeters = totalDistance / 4330.0
+                let distanceText = self.formatDistance(distanceMeters)
+                let keystrokesText = self.formatCount(totalKeystrokes)
+
+                button.title = " \(distanceText) · \(keystrokesText)"
+            }
         }
-
-        let distanceMeters = totalDistance / 4330.0
-        let distanceText = formatDistance(distanceMeters)
-        let keystrokesText = formatCount(totalKeystrokes)
-
-        button.title = " \(distanceText) · \(keystrokesText)"
     }
 
     private func formatDistance(_ meters: Double) -> String {


### PR DESCRIPTION
## Summary
- Move DatabaseManager.shared.getDailySummary call from MainActor to a Task.detached background context
- Read in-memory tracker stats (MouseTracker, KeyboardTracker) on MainActor first, then perform the DB query off-thread
- Hop back to MainActor.run to update the menu bar button title

Closes #7

## Test plan
- Verify the menu bar live stats label still updates every 2 seconds with correct distance and keystroke counts
- Confirm no UI hitches or freezes during the timer callback by profiling with Instruments (Time Profiler)
- Test with live stats toggled off to ensure the early return still clears the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)