### PR TITLE
chore: Add App Sandbox and input monitoring entitlements

### DIFF
--- a/InputMetrics/InputMetrics/InputMetrics.entitlements
+++ b/InputMetrics/InputMetrics/InputMetrics.entitlements
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.device.input-monitoring</key>
+	<true/>
+	<key>com.apple.security.personal-information.accessibility</key>
+	<true/>
+</dict>
 </plist>


### PR DESCRIPTION
## Summary
- Enable App Sandbox for Mac App Store distribution
- Add input monitoring entitlement for keystroke and mouse tracking
- Add accessibility entitlement for event tap functionality

Closes #19

## Test plan
- Verify the app builds without code signing errors
- Confirm input monitoring still works under the sandbox
- Confirm accessibility event tap functionality is preserved
- Test that the app passes Mac App Store entitlement validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)