### PR TITLE
perf(mouse): Batch mouse heatmap DB writes

### DIFF
--- a/InputMetrics/InputMetrics/Services/DatabaseManager.swift
+++ b/InputMetrics/InputMetrics/Services/DatabaseManager.swift
@@ -190,6 +190,39 @@ final class DatabaseManager: @unchecked Sendable {
         }
     }
 
+    func batchUpdateMouseHeatmap(_ buffer: [HeatmapBucketKey: Int]) {
+        guard let db = dbQueue else { return }
+
+        dbQueue_serial.async {
+            do {
+                try db.write { db in
+                    for (key, count) in buffer {
+                        if var entry = try MouseHeatmapEntry
+                            .filter(MouseHeatmapEntry.Columns.date == key.date)
+                            .filter(MouseHeatmapEntry.Columns.screenId == key.screenId)
+                            .filter(MouseHeatmapEntry.Columns.bucketX == key.bucketX)
+                            .filter(MouseHeatmapEntry.Columns.bucketY == key.bucketY)
+                            .fetchOne(db) {
+                            entry.clickCount += count
+                            try entry.update(db)
+                        } else {
+                            let newEntry = MouseHeatmapEntry(
+                                date: key.date,
+                                screenId: key.screenId,
+                                bucketX: key.bucketX,
+                                bucketY: key.bucketY,
+                                clickCount: count
+                            )
+                            try newEntry.insert(db)
+                        }
+                    }
+                }
+            } catch {
+                print("Error batch updating mouse heatmap: \(error)")
+            }
+        }
+    }
+
     func getMouseHeatmap(date: String) -> [MouseHeatmapEntry] {
         guard let db = dbQueue else { return [] }
 

--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -6,6 +6,13 @@ enum ClickType: Sendable {
     case left, right, middle
 }
 
+struct HeatmapBucketKey: Hashable {
+    let date: String
+    let screenId: String
+    let bucketX: Int
+    let bucketY: Int
+}
+
 @MainActor
 class MouseTracker {
     static let shared = MouseTracker()
@@ -15,6 +22,8 @@ class MouseTracker {
     private var leftClicks: Int = 0
     private var rightClicks: Int = 0
     private var middleClicks: Int = 0
+
+    private var heatmapBuffer: [HeatmapBucketKey: Int] = [:]
 
     private var persistTimer: Timer?
     private let persistInterval: TimeInterval = 30.0
@@ -47,17 +56,12 @@ class MouseTracker {
             middleClicks += 1
         }
 
-        // Update heatmap
         let bucket = bucketForPoint(point)
         let screenId = getScreenId(for: point)
         let today = getTodayString()
 
-        DatabaseManager.shared.updateMouseHeatmap(
-            date: today,
-            screenId: screenId,
-            bucketX: bucket.x,
-            bucketY: bucket.y
-        )
+        let key = HeatmapBucketKey(date: today, screenId: screenId, bucketX: bucket.x, bucketY: bucket.y)
+        heatmapBuffer[key, default: 0] += 1
     }
 
     private func setupPersistTimer() {
@@ -79,18 +83,24 @@ class MouseTracker {
             middleClicks: middleClicks
         )
 
+        if !heatmapBuffer.isEmpty {
+            DatabaseManager.shared.batchUpdateMouseHeatmap(heatmapBuffer)
+        }
+
         // Reset all counters after persist
         let persistedDistance = accumulatedDistance
         let persistedLeft = leftClicks
         let persistedRight = rightClicks
         let persistedMiddle = middleClicks
+        let persistedHeatmapBuckets = heatmapBuffer.count
 
         accumulatedDistance = 0
         leftClicks = 0
         rightClicks = 0
         middleClicks = 0
+        heatmapBuffer.removeAll()
 
-        print("Mouse data persisted: \(persistedDistance)px, L:\(persistedLeft) R:\(persistedRight) M:\(persistedMiddle)")
+        print("Mouse data persisted: \(persistedDistance)px, L:\(persistedLeft) R:\(persistedRight) M:\(persistedMiddle), heatmap buckets:\(persistedHeatmapBuckets)")
     }
 
     func reset() {
@@ -99,6 +109,7 @@ class MouseTracker {
         rightClicks = 0
         middleClicks = 0
         lastPoint = nil
+        heatmapBuffer.removeAll()
     }
 
     func getCurrentStats() -> (distance: Double, left: Int, right: Int, middle: Int) {


### PR DESCRIPTION
## Summary
- Accumulate click heatmap counts in an in-memory dictionary instead of writing to the DB on every click
- Flush all buffered heatmap data in a single DB transaction during the existing 30-second persist timer via batchUpdateMouseHeatmap
- Clear heatmap buffer on reset() alongside other counters

Closes #6

## Test plan
- Verify clicks still appear correctly in the heatmap view after the 30-second flush interval
- Confirm rapid clicking does not trigger individual DB writes (check console logs for batch bucket count)
- Verify persistData() on app termination still flushes buffered heatmap data
- Verify reset() clears the heatmap buffer along with other counters

Generated with [Claude Code](https://claude.com/claude-code)