### PR TITLE
feat(heatmap): Add multi-screen heatmap filtering

### DIFF
--- a/InputMetrics/InputMetrics/Services/DatabaseManager.swift
+++ b/InputMetrics/InputMetrics/Services/DatabaseManager.swift
@@ -199,17 +199,39 @@ final class DatabaseManager: @unchecked Sendable {
         }
     }
 
-    func getMouseHeatmap(date: String) -> [MouseHeatmapEntry] {
+    func getMouseHeatmap(date: String, screenId: String? = nil) -> [MouseHeatmapEntry] {
         guard let db = dbQueue else { return [] }
 
         do {
             return try db.read { db in
-                try MouseHeatmapEntry
+                var request = MouseHeatmapEntry
                     .filter(MouseHeatmapEntry.Columns.date == date)
-                    .fetchAll(db)
+
+                if let screenId {
+                    request = request.filter(MouseHeatmapEntry.Columns.screenId == screenId)
+                }
+
+                return try request.fetchAll(db)
             }
         } catch {
             print("Error fetching mouse heatmap: \(error)")
+            return []
+        }
+    }
+
+    func getDistinctScreenIds(date: String) -> [String] {
+        guard let db = dbQueue else { return [] }
+
+        do {
+            return try db.read { db in
+                try String.fetchAll(
+                    db,
+                    sql: "SELECT DISTINCT screen_id FROM mouse_heatmap WHERE date = ? ORDER BY screen_id",
+                    arguments: [date]
+                )
+            }
+        } catch {
+            print("Error fetching screen IDs: \(error)")
             return []
         }
     }

--- a/InputMetrics/InputMetrics/Views/HeatmapView.swift
+++ b/InputMetrics/InputMetrics/Views/HeatmapView.swift
@@ -2,45 +2,73 @@ import SwiftUI
 
 struct HeatmapView: View {
     @State private var heatmapData: [[Int]] = []
+    @State private var screenIds: [String] = []
+    @State private var selectedScreenId: String?
 
     private var maxValue: Int {
         heatmapData.flatMap { $0 }.max() ?? 1
     }
 
     var body: some View {
-        Canvas { context, size in
-            let cellWidth = size.width / CGFloat(Constants.heatmapGridSize)
-            let cellHeight = size.height / CGFloat(Constants.heatmapGridSize)
-
-            guard !heatmapData.isEmpty else { return }
-
-            for y in 0..<Constants.heatmapGridSize {
-                for x in 0..<Constants.heatmapGridSize {
-                    let value = heatmapData[y][x]
-                    let intensity = Double(value) / Double(maxValue)
-
-                    let rect = CGRect(
-                        x: CGFloat(x) * cellWidth,
-                        y: CGFloat(y) * cellHeight,
-                        width: cellWidth,
-                        height: cellHeight
-                    )
-
-                    let color = colorForIntensity(intensity)
-                    context.fill(
-                        Path(roundedRect: rect, cornerRadius: 0),
-                        with: .color(color)
-                    )
+        VStack(spacing: 8) {
+            if !screenIds.isEmpty {
+                Picker("Screen", selection: $selectedScreenId) {
+                    Text("All Screens").tag(String?.none)
+                    ForEach(screenIds, id: \.self) { id in
+                        Text(id).tag(String?.some(id))
+                    }
+                }
+                .pickerStyle(.menu)
+                .accessibilityLabel("Screen filter")
+                .onChange(of: selectedScreenId) { _, _ in
+                    loadHeatmapData()
                 }
             }
+
+            Canvas { context, size in
+                let cellWidth = size.width / CGFloat(Constants.heatmapGridSize)
+                let cellHeight = size.height / CGFloat(Constants.heatmapGridSize)
+
+                guard !heatmapData.isEmpty else { return }
+
+                for y in 0..<Constants.heatmapGridSize {
+                    for x in 0..<Constants.heatmapGridSize {
+                        let value = heatmapData[y][x]
+                        let intensity = Double(value) / Double(maxValue)
+
+                        let rect = CGRect(
+                            x: CGFloat(x) * cellWidth,
+                            y: CGFloat(y) * cellHeight,
+                            width: cellWidth,
+                            height: cellHeight
+                        )
+
+                        let color = colorForIntensity(intensity)
+                        context.fill(
+                            Path(roundedRect: rect, cornerRadius: 0),
+                            with: .color(color)
+                        )
+                    }
+                }
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Mouse click heatmap")
+            .background(Color.black.opacity(0.1))
+            .cornerRadius(8)
         }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Mouse click heatmap")
-        .background(Color.black.opacity(0.1))
-        .cornerRadius(8)
         .onAppear {
+            loadScreenIds()
             loadHeatmapData()
         }
+    }
+
+    private func loadScreenIds() {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        let today = formatter.string(from: Date())
+
+        screenIds = DatabaseManager.shared.getDistinctScreenIds(date: today)
     }
 
     private func loadHeatmapData() {
@@ -49,12 +77,10 @@ struct HeatmapView: View {
         formatter.dateFormat = "yyyy-MM-dd"
         let today = formatter.string(from: Date())
 
-        let entries = DatabaseManager.shared.getMouseHeatmap(date: today)
+        let entries = DatabaseManager.shared.getMouseHeatmap(date: today, screenId: selectedScreenId)
 
-        // Initialize 50x50 grid with zeros
         var grid = Array(repeating: Array(repeating: 0, count: Constants.heatmapGridSize), count: Constants.heatmapGridSize)
 
-        // Fill in the click counts
         for entry in entries {
             guard entry.bucketX >= 0 && entry.bucketY >= 0 && entry.bucketX < Constants.heatmapGridSize && entry.bucketY < Constants.heatmapGridSize else { continue }
             grid[entry.bucketY][entry.bucketX] += entry.clickCount


### PR DESCRIPTION
## Summary
- Add screen picker/filter to HeatmapView with All Screens default and per-screen options
- Add getDistinctScreenIds(date:) to DatabaseManager to query available screens
- Extend getMouseHeatmap(date:screenId:) with optional screenId filter parameter

Closes #13

## Test plan
- Verify heatmap loads with All Screens selected by default (aggregates all screen data)
- Connect multiple monitors, generate click data, confirm each screen appears in the picker
- Select a specific screen and verify heatmap only shows clicks from that screen
- Switch between screens and All Screens to confirm data updates correctly

Generated with [Claude Code](https://claude.com/claude-code)