### PR TITLE
feat(tracking): Implement hourly granularity tracking

### DIFF
--- a/InputMetrics/InputMetrics/Services/DatabaseManager.swift
+++ b/InputMetrics/InputMetrics/Services/DatabaseManager.swift
@@ -142,6 +142,77 @@ final class DatabaseManager: @unchecked Sendable {
         }
     }
 
+    // MARK: - Hourly Summary Operations
+
+    func updateHourlySummary(
+        date: String,
+        hour: Int,
+        mouseDistance: Double = 0,
+        mouseClicks: Int = 0,
+        keystrokes: Int = 0
+    ) {
+        guard let db = dbQueue else { return }
+
+        dbQueue_serial.async {
+            do {
+                try db.write { db in
+                    if var summary = try HourlySummary
+                        .filter(HourlySummary.Columns.date == date)
+                        .filter(HourlySummary.Columns.hour == hour)
+                        .fetchOne(db) {
+                        summary.mouseDistancePx += mouseDistance
+                        summary.mouseClicks += mouseClicks
+                        summary.keystrokes += keystrokes
+                        try summary.update(db)
+                    } else {
+                        let newSummary = HourlySummary(
+                            date: date,
+                            hour: hour,
+                            mouseDistancePx: mouseDistance,
+                            mouseClicks: mouseClicks,
+                            keystrokes: keystrokes
+                        )
+                        try newSummary.insert(db)
+                    }
+                }
+            } catch {
+                print("Error updating hourly summary: \(error)")
+            }
+        }
+    }
+
+    func getHourlySummaries(date: String) -> [HourlySummary] {
+        guard let db = dbQueue else { return [] }
+
+        do {
+            return try db.read { db in
+                try HourlySummary
+                    .filter(HourlySummary.Columns.date == date)
+                    .order(HourlySummary.Columns.hour)
+                    .fetchAll(db)
+            }
+        } catch {
+            print("Error fetching hourly summaries: \(error)")
+            return []
+        }
+    }
+
+    func getHourlySummaries(from startDate: String, to endDate: String) -> [HourlySummary] {
+        guard let db = dbQueue else { return [] }
+
+        do {
+            return try db.read { db in
+                try HourlySummary
+                    .filter(HourlySummary.Columns.date >= startDate && HourlySummary.Columns.date <= endDate)
+                    .order(HourlySummary.Columns.date, HourlySummary.Columns.hour)
+                    .fetchAll(db)
+            }
+        } catch {
+            print("Error fetching hourly summaries: \(error)")
+            return []
+        }
+    }
+
     // MARK: - Mouse Heatmap Operations
 
     func updateMouseHeatmap(date: String, screenId: String, bucketX: Int, bucketY: Int) {
@@ -338,6 +409,21 @@ final class DatabaseManager: @unchecked Sendable {
             }
         } catch {
             print("Error fetching all daily summaries: \(error)")
+            return []
+        }
+    }
+
+    func getAllHourlySummaries() -> [HourlySummary] {
+        guard let db = dbQueue else { return [] }
+
+        do {
+            return try db.read { db in
+                try HourlySummary
+                    .order(HourlySummary.Columns.date, HourlySummary.Columns.hour)
+                    .fetchAll(db)
+            }
+        } catch {
+            print("Error fetching all hourly summaries: \(error)")
             return []
         }
     }

--- a/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
+++ b/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
@@ -40,9 +40,16 @@ class KeyboardTracker {
 
     func persistData() {
         let today = getTodayString()
+        let currentHour = getCurrentHour()
 
         DatabaseManager.shared.updateDailySummary(
             date: today,
+            keystrokes: totalKeystrokes
+        )
+
+        DatabaseManager.shared.updateHourlySummary(
+            date: today,
+            hour: currentHour,
             keystrokes: totalKeystrokes
         )
 
@@ -78,6 +85,10 @@ class KeyboardTracker {
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: Date())
+    }
+
+    private func getCurrentHour() -> Int {
+        Calendar.current.component(.hour, from: Date())
     }
 
     nonisolated deinit {

--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -134,6 +134,7 @@ class MouseTracker {
 
     func persistData() {
         let today = getTodayString()
+        let currentHour = getCurrentHour()
 
         DatabaseManager.shared.updateDailySummary(
             date: today,
@@ -141,6 +142,13 @@ class MouseTracker {
             leftClicks: leftClicks,
             rightClicks: rightClicks,
             middleClicks: middleClicks
+        )
+
+        DatabaseManager.shared.updateHourlySummary(
+            date: today,
+            hour: currentHour,
+            mouseDistance: accumulatedDistance,
+            mouseClicks: leftClicks + rightClicks + middleClicks
         )
 
         if !heatmapBuffer.isEmpty {
@@ -207,6 +215,10 @@ class MouseTracker {
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: Date())
+    }
+
+    private func getCurrentHour() -> Int {
+        Calendar.current.component(.hour, from: Date())
     }
 
     nonisolated deinit {


### PR DESCRIPTION
## Summary
- Write hourly summaries alongside daily summaries in the MouseTracker and KeyboardTracker 30s flush cycle
- Add updateHourlySummary upsert method to DatabaseManager (keyed by date + hour composite primary key)
- Add getHourlySummaries and getAllHourlySummaries read methods for querying hourly data

Closes #10

## Test plan
- Launch the app and verify mouse movement, clicks, and keystrokes are recorded in both daily_summary and hourly_summary tables
- Inspect the SQLite database after a few flush cycles to confirm hourly rows are created with correct date/hour values
- Verify that data accumulates correctly when multiple flushes occur within the same hour
- Test across an hour boundary to confirm a new hourly row is created for the next hour
- Confirm resetAllData still clears the hourly_summary table

🤖 Generated with [Claude Code](https://claude.com/claude-code)