### PR TITLE
refactor: Consolidate duplicate distance formatting logic

### DIFF
--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -95,25 +95,8 @@ struct MenuBarView: View {
                         .font(.title2)
                         .foregroundStyle(.blue)
 
-                    let meters = DistanceConverter.pixelsToMeters(mouseDistance)
-                    if preferences.distanceUnit == .metric {
-                        if meters < 1000 {
-                            Text(String(format: "%.1f m", meters))
-                                .font(.title.bold())
-                        } else {
-                            Text(String(format: "%.2f km", meters / 1000))
-                                .font(.title.bold())
-                        }
-                    } else {
-                        let feet = meters * 3.28084
-                        if feet < 5280 {
-                            Text(String(format: "%.1f ft", feet))
-                                .font(.title.bold())
-                        } else {
-                            Text(String(format: "%.2f mi", feet / 5280))
-                                .font(.title.bold())
-                        }
-                    }
+                    Text(DistanceConverter.formatDistance(mouseDistance, unit: preferences.distanceUnit))
+                        .font(.title.bold())
 
                     Text("Distance")
                         .font(.caption)
@@ -292,25 +275,8 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    let meters = DistanceConverter.pixelsToMeters(allTimeDistance)
-                    if preferences.distanceUnit == .metric {
-                        if meters < 1000 {
-                            Text(String(format: "%.0f m", meters))
-                                .font(.title2.bold().monospacedDigit())
-                        } else {
-                            Text(String(format: "%.1f km", meters / 1000))
-                                .font(.title2.bold().monospacedDigit())
-                        }
-                    } else {
-                        let feet = meters * 3.28084
-                        if feet < 5280 {
-                            Text(String(format: "%.0f ft", feet))
-                                .font(.title2.bold().monospacedDigit())
-                        } else {
-                            Text(String(format: "%.1f mi", feet / 5280))
-                                .font(.title2.bold().monospacedDigit())
-                        }
-                    }
+                    Text(DistanceConverter.formatDistance(allTimeDistance, unit: preferences.distanceUnit))
+                        .font(.title2.bold().monospacedDigit())
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()


### PR DESCRIPTION
## Summary
- Replace inline imperial/metric distance conversion in MenuBarView with calls to DistanceConverter.formatDistance()
- Remove two instances of hardcoded * 3.28084 conversion factor (today's distance card and all-time stats)
- Net reduction of 34 lines, single source of truth for distance formatting

Closes #16

## Test plan
- Verify today's distance card displays correctly in both metric and imperial units
- Verify all-time distance stat displays correctly in both metric and imperial units
- Toggle distance unit in Settings and confirm both cards update consistently
- Confirm chart Y-axis label still shows correct unit (km/mi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)