### PR TITLE
perf(mouse): Cache screen bounds instead of recalculating per click

### DIFF
--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -19,8 +19,68 @@ class MouseTracker {
     private var persistTimer: Timer?
     private let persistInterval: TimeInterval = 30.0
 
+    // Cached screen geometry — invalidated on display configuration changes
+    private struct ScreenCache {
+        let primaryHeight: CGFloat
+        let boundingMinX: CGFloat
+        let boundingMinY: CGFloat
+        let boundingWidth: CGFloat
+        let boundingHeight: CGFloat
+        let screens: [(frame: CGRect, id: String)]
+    }
+
+    private var screenCache: ScreenCache?
+
     private init() {
         setupPersistTimer()
+        rebuildScreenCache()
+
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.rebuildScreenCache()
+            }
+        }
+    }
+
+    private func rebuildScreenCache() {
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else {
+            screenCache = nil
+            return
+        }
+
+        let primaryHeight = screens[0].frame.height
+
+        var minX = CGFloat.infinity
+        var minY = CGFloat.infinity
+        var maxX = -CGFloat.infinity
+        var maxY = -CGFloat.infinity
+
+        var cachedScreens: [(frame: CGRect, id: String)] = []
+
+        for screen in screens {
+            let frame = screen.frame
+            minX = min(minX, frame.minX)
+            minY = min(minY, frame.minY)
+            maxX = max(maxX, frame.maxX)
+            maxY = max(maxY, frame.maxY)
+
+            let id = (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.stringValue ?? "primary"
+            cachedScreens.append((frame: frame, id: id))
+        }
+
+        screenCache = ScreenCache(
+            primaryHeight: primaryHeight,
+            boundingMinX: minX,
+            boundingMinY: minY,
+            boundingWidth: maxX - minX,
+            boundingHeight: maxY - minY,
+            screens: cachedScreens
+        )
     }
 
     func trackMovement(to point: CGPoint) {
@@ -106,32 +166,14 @@ class MouseTracker {
     }
 
     private func bucketForPoint(_ point: CGPoint) -> (x: Int, y: Int) {
-        let screens = NSScreen.screens
-        guard !screens.isEmpty else { return (0, 0) }
+        guard let cache = screenCache else { return (0, 0) }
 
         // Convert CG Y (origin bottom-left) to AppKit Y (origin top-left)
-        let primaryHeight = NSScreen.screens[0].frame.height
-        let appKitY = primaryHeight - point.y
-
-        var minX = CGFloat.infinity
-        var minY = CGFloat.infinity
-        var maxX = -CGFloat.infinity
-        var maxY = -CGFloat.infinity
-
-        for screen in screens {
-            let frame = screen.frame
-            minX = min(minX, frame.minX)
-            minY = min(minY, frame.minY)
-            maxX = max(maxX, frame.maxX)
-            maxY = max(maxY, frame.maxY)
-        }
-
-        let width = maxX - minX
-        let height = maxY - minY
+        let appKitY = cache.primaryHeight - point.y
 
         // Normalize to 50x50 grid
-        let normalizedX = (point.x - minX) / width
-        let normalizedY = (appKitY - minY) / height
+        let normalizedX = (point.x - cache.boundingMinX) / cache.boundingWidth
+        let normalizedY = (appKitY - cache.boundingMinY) / cache.boundingHeight
         let bucketX = min(49, max(0, Int(normalizedX * 50)))
         let bucketY = min(49, max(0, Int(normalizedY * 50)))
 
@@ -139,10 +181,11 @@ class MouseTracker {
     }
 
     private func getScreenId(for point: CGPoint) -> String {
-        // Find which screen contains this point
-        for screen in NSScreen.screens {
+        guard let cache = screenCache else { return "primary" }
+
+        for screen in cache.screens {
             if screen.frame.contains(point) {
-                return (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.stringValue ?? "primary"
+                return screen.id
             }
         }
         return "primary"


### PR DESCRIPTION
## Summary
- Cache NSScreen.screens geometry (bounding rect, primary height, per-screen frames and IDs) in a ScreenCache struct
- bucketForPoint and getScreenId now read from the cache instead of iterating NSScreen.screens on every mouse click
- Invalidate and rebuild the cache on NSApplication.didChangeScreenParametersNotification so display topology changes are handled correctly

Closes #39

## Test plan
- Verify heatmap data is recorded correctly with a single monitor
- Verify heatmap data is recorded correctly with multiple monitors
- Connect/disconnect an external display and confirm the cache rebuilds (heatmap continues to record accurate screen IDs and bucket positions)
- Confirm no regression in mouse distance or click count tracking

Generated with [Claude Code](https://claude.com/claude-code)