### PR TITLE
perf(stats): Cache all-time stats to avoid repeated table scans

### DIFF
--- a/InputMetrics/InputMetrics/Services/DatabaseManager.swift
+++ b/InputMetrics/InputMetrics/Services/DatabaseManager.swift
@@ -251,6 +251,49 @@ final class DatabaseManager: @unchecked Sendable {
         }
     }
 
+    // MARK: - Aggregated Totals
+
+    struct AllTimeTotals {
+        var distance: Double
+        var clicksLeft: Int
+        var clicksRight: Int
+        var clicksMiddle: Int
+        var keystrokes: Int
+
+        static let zero = AllTimeTotals(distance: 0, clicksLeft: 0, clicksRight: 0, clicksMiddle: 0, keystrokes: 0)
+
+        var totalClicks: Int { clicksLeft + clicksRight + clicksMiddle }
+    }
+
+    func getAllTimeTotals() -> AllTimeTotals {
+        guard let db = dbQueue else { return .zero }
+
+        do {
+            return try db.read { db in
+                let row = try Row.fetchOne(db, sql: """
+                    SELECT
+                        COALESCE(SUM(mouse_distance_px), 0) AS distance,
+                        COALESCE(SUM(mouse_clicks_left), 0) AS clicks_left,
+                        COALESCE(SUM(mouse_clicks_right), 0) AS clicks_right,
+                        COALESCE(SUM(mouse_clicks_middle), 0) AS clicks_middle,
+                        COALESCE(SUM(keystrokes), 0) AS keystrokes
+                    FROM daily_summary
+                    """)
+                guard let row else { return .zero }
+                return AllTimeTotals(
+                    distance: row["distance"],
+                    clicksLeft: row["clicks_left"],
+                    clicksRight: row["clicks_right"],
+                    clicksMiddle: row["clicks_middle"],
+                    keystrokes: row["keystrokes"]
+                )
+            }
+        } catch {
+            print("Error fetching all-time totals: \(error)")
+            return .zero
+        }
+    }
+
     // MARK: - Fetch All (for export)
 
     func getAllDailySummaries() -> [DailySummary] {

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -16,8 +16,11 @@ struct MenuBarView: View {
     @State private var allTimeDistance: Double = 0
     @State private var allTimeClicks: Int = 0
     @State private var allTimeKeystrokes: Int = 0
+    @State private var cachedTotals: DatabaseManager.AllTimeTotals = .zero
+    @State private var lastCacheTime: Date = .distantPast
 
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    private let cacheInterval: TimeInterval = 30
 
     enum MetricTab {
         case mouse, keyboard
@@ -74,14 +77,16 @@ struct MenuBarView: View {
         .frame(width: 420, height: 600)
         .onReceive(timer) { _ in
             updateStats()
-            loadAllTimeStats()
+            refreshAllTimeTotalsIfNeeded()
+            updateAllTimeStats()
         }
         .onAppear {
             updateStats()
             loadChartData()
             loadHeatmapData()
             loadKeyboardData()
-            loadAllTimeStats()
+            refreshCachedTotals()
+            updateAllTimeStats()
         }
     }
 
@@ -403,28 +408,21 @@ struct MenuBarView: View {
         keyboardEntries = DatabaseManager.shared.getKeyboardEntries(date: today)
     }
 
-    private func loadAllTimeStats() {
-        let allSummaries = DatabaseManager.shared.getAllDailySummaries()
+    private func refreshCachedTotals() {
+        cachedTotals = DatabaseManager.shared.getAllTimeTotals()
+        lastCacheTime = Date()
+    }
 
-        var totalDistance: Double = 0
-        var totalClicks: Int = 0
-        var totalKeys: Int = 0
+    private func refreshAllTimeTotalsIfNeeded() {
+        guard Date().timeIntervalSince(lastCacheTime) >= cacheInterval else { return }
+        refreshCachedTotals()
+    }
 
-        for summary in allSummaries {
-            totalDistance += summary.mouseDistancePx
-            totalClicks += summary.mouseClicksLeft + summary.mouseClicksRight + summary.mouseClicksMiddle
-            totalKeys += summary.keystrokes
-        }
-
-        // Add current session counters (not yet persisted)
+    private func updateAllTimeStats() {
         let mouseStats = MouseTracker.shared.getCurrentStats()
-        totalDistance += mouseStats.distance
-        totalClicks += mouseStats.left + mouseStats.right + mouseStats.middle
-        totalKeys += KeyboardTracker.shared.getCurrentKeystrokes()
-
-        allTimeDistance = totalDistance
-        allTimeClicks = totalClicks
-        allTimeKeystrokes = totalKeys
+        allTimeDistance = cachedTotals.distance + mouseStats.distance
+        allTimeClicks = cachedTotals.totalClicks + mouseStats.left + mouseStats.right + mouseStats.middle
+        allTimeKeystrokes = cachedTotals.keystrokes + KeyboardTracker.shared.getCurrentKeystrokes()
     }
 
     private func chartDistance(_ pixels: Double) -> Double {

--- a/InputMetrics/InputMetrics/Views/MouseStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/MouseStatsView.swift
@@ -102,29 +102,15 @@ struct MouseStatsView: View {
     }
 
     private func loadAllTimeStats() {
-        let allSummaries = DatabaseManager.shared.getAllDailySummaries()
-
-        var totalDistance: Double = 0
-        var totalClicksLeft: Int = 0
-        var totalClicksRight: Int = 0
-        var totalClicksMiddle: Int = 0
-        var totalKeystrokes: Int = 0
-
-        for summary in allSummaries {
-            totalDistance += summary.mouseDistancePx
-            totalClicksLeft += summary.mouseClicksLeft
-            totalClicksRight += summary.mouseClicksRight
-            totalClicksMiddle += summary.mouseClicksMiddle
-            totalKeystrokes += summary.keystrokes
-        }
+        let totals = DatabaseManager.shared.getAllTimeTotals()
 
         allTimeStats = DailySummary(
             date: "",
-            mouseDistancePx: totalDistance,
-            mouseClicksLeft: totalClicksLeft,
-            mouseClicksRight: totalClicksRight,
-            mouseClicksMiddle: totalClicksMiddle,
-            keystrokes: totalKeystrokes
+            mouseDistancePx: totals.distance,
+            mouseClicksLeft: totals.clicksLeft,
+            mouseClicksRight: totals.clicksRight,
+            mouseClicksMiddle: totals.clicksMiddle,
+            keystrokes: totals.keystrokes
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add SQL SUM() aggregate query (getAllTimeTotals()) to DatabaseManager, replacing the full table scan that fetched every DailySummary row
- Cache DB totals in MenuBarView and only refresh every 30 seconds (aligned with the persist interval), instead of querying on every 1-second timer tick
- On each timer tick, cheaply overlay current in-memory session counters on top of the cached totals
- Apply the same aggregate query in MouseStatsView.loadAllTimeStats()

Closes #4

## Test plan
- Verify all-time stats in the menu bar popover still update correctly when the app is running
- Confirm totals include both persisted DB data and current unsaved session counters
- Check that after 30 seconds (when data is persisted), the cached totals refresh and session counters reset without a visible jump
- Open the dashboard MouseStatsView and verify all-time stats load correctly
- With a large dataset, confirm reduced CPU usage compared to the previous full table scan approach

Generated with [Claude Code](https://claude.com/claude-code)