### PR TITLE
perf(events): Replace per-event Task with synchronous dispatch

### DIFF
--- a/InputMetrics/InputMetrics/Services/EventMonitor.swift
+++ b/InputMetrics/InputMetrics/Services/EventMonitor.swift
@@ -77,14 +77,18 @@ class EventMonitor {
         print("Event monitoring stopped")
     }
 
-    private func handleEvent(type: CGEventType, event: CGEvent) {
+    nonisolated private func handleEvent(type: CGEventType, event: CGEvent) {
         // Extract all values synchronously before the callback returns,
         // since the CGEvent may be deallocated after the callback exits.
         let location = event.location
         let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
         let flags = event.flags
 
-        Task { @MainActor in
+        // The event tap callback runs on the main thread's run loop, so we
+        // can dispatch synchronously via assumeIsolated instead of spawning
+        // a Task per event. This eliminates Task object overhead at high
+        // event rates and guarantees FIFO processing order.
+        MainActor.assumeIsolated {
             switch type {
             case .mouseMoved:
                 MouseTracker.shared.trackMovement(to: location)


### PR DESCRIPTION
## Summary
- Replace `Task { @MainActor in }` with `MainActor.assumeIsolated` in `EventMonitor.handleEvent`
- The event tap callback already executes on the main thread run loop, so synchronous dispatch is safe
- Eliminates hundreds of Task object allocations per second during high event rates
- Guarantees FIFO event processing order (Tasks do not guarantee execution order)

Closes #43

## Test plan
- Verify mouse movement tracking still works correctly by moving the mouse and checking heatmap data
- Verify click tracking (left, right, middle) still registers in the database
- Verify keyboard keystroke tracking still records key codes and modifier flags
- Confirm no crashes or assertion failures from assumeIsolated (would indicate an unexpected threading issue)
- Monitor memory usage under sustained high-frequency mouse movement to confirm reduced overhead

Generated with [Claude Code](https://claude.com/claude-code)