### PR TITLE
feat(data): Add configurable data retention/cleanup policy

### DIFF
--- a/InputMetrics/InputMetrics/AppDelegate.swift
+++ b/InputMetrics/InputMetrics/AppDelegate.swift
@@ -43,6 +43,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Hide dock icon for menu bar-only app
         NSApp.setActivationPolicy(.accessory)
 
+        // Run data retention cleanup
+        let retentionPeriod = UserPreferences.shared.dataRetentionPeriod
+        if let days = retentionPeriod.days {
+            DatabaseManager.shared.pruneOldData(olderThanDays: days)
+        }
+
         // Start event monitoring on main actor
         Task { @MainActor in
             EventMonitor.shared.start()

--- a/InputMetrics/InputMetrics/Services/DatabaseManager.swift
+++ b/InputMetrics/InputMetrics/Services/DatabaseManager.swift
@@ -311,4 +311,74 @@ final class DatabaseManager: @unchecked Sendable {
             }
         }
     }
+
+    // MARK: - Data Retention
+
+    func pruneOldData(olderThanDays days: Int) {
+        guard let db = dbQueue else { return }
+
+        let calendar = Calendar.current
+        guard let cutoffDate = calendar.date(byAdding: .day, value: -days, to: Date()) else { return }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        let cutoffString = formatter.string(from: cutoffDate)
+
+        dbQueue_serial.async {
+            do {
+                try db.write { db in
+                    try db.execute(sql: "DELETE FROM daily_summary WHERE date < ?", arguments: [cutoffString])
+                    try db.execute(sql: "DELETE FROM mouse_heatmap WHERE date < ?", arguments: [cutoffString])
+                    try db.execute(sql: "DELETE FROM keyboard_heatmap WHERE date < ?", arguments: [cutoffString])
+                    try db.execute(sql: "DELETE FROM hourly_summary WHERE date < ?", arguments: [cutoffString])
+                    try db.execute(sql: "VACUUM")
+                }
+                print("Pruned data older than \(cutoffString)")
+            } catch {
+                print("Error pruning old data: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Database Size
+
+    func getDatabaseFileSize() -> Int64 {
+        do {
+            let fileManager = FileManager.default
+            let appSupport = try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: false
+            )
+
+            let dbPath = appSupport
+                .appendingPathComponent("InputMetrics", isDirectory: true)
+                .appendingPathComponent("metrics.db")
+
+            let attributes = try fileManager.attributesOfItem(atPath: dbPath.path)
+            return attributes[.size] as? Int64 ?? 0
+        } catch {
+            print("Error getting database file size: \(error)")
+            return 0
+        }
+    }
+
+    func getRecordCounts() -> (dailySummaries: Int, mouseHeatmap: Int, keyboardHeatmap: Int, hourlySummaries: Int) {
+        guard let db = dbQueue else { return (0, 0, 0, 0) }
+
+        do {
+            return try db.read { db in
+                let daily = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM daily_summary") ?? 0
+                let mouse = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM mouse_heatmap") ?? 0
+                let keyboard = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM keyboard_heatmap") ?? 0
+                let hourly = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM hourly_summary") ?? 0
+                return (daily, mouse, keyboard, hourly)
+            }
+        } catch {
+            print("Error getting record counts: \(error)")
+            return (0, 0, 0, 0)
+        }
+    }
 }

--- a/InputMetrics/InputMetrics/Utilities/UserPreferences.swift
+++ b/InputMetrics/InputMetrics/Utilities/UserPreferences.swift
@@ -1,5 +1,32 @@
 import Foundation
 
+enum DataRetentionPeriod: String, CaseIterable, Identifiable {
+    case threeMonths = "3months"
+    case sixMonths = "6months"
+    case oneYear = "1year"
+    case forever = "forever"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .threeMonths: return "3 months"
+        case .sixMonths: return "6 months"
+        case .oneYear: return "1 year"
+        case .forever: return "Forever"
+        }
+    }
+
+    var days: Int? {
+        switch self {
+        case .threeMonths: return 90
+        case .sixMonths: return 180
+        case .oneYear: return 365
+        case .forever: return nil
+        }
+    }
+}
+
 @MainActor
 class UserPreferences: ObservableObject {
     static let shared = UserPreferences()
@@ -16,9 +43,18 @@ class UserPreferences: ObservableObject {
         }
     }
 
+    @Published var dataRetentionPeriod: DataRetentionPeriod {
+        didSet {
+            UserDefaults.standard.set(dataRetentionPeriod.rawValue, forKey: "dataRetentionPeriod")
+        }
+    }
+
     private init() {
         let savedUnit = UserDefaults.standard.string(forKey: "distanceUnit") ?? "metric"
         self.distanceUnit = savedUnit == "metric" ? .metric : .imperial
         self.showLiveStats = UserDefaults.standard.object(forKey: "showLiveStats") as? Bool ?? true
+
+        let savedRetention = UserDefaults.standard.string(forKey: "dataRetentionPeriod") ?? "forever"
+        self.dataRetentionPeriod = DataRetentionPeriod(rawValue: savedRetention) ?? .forever
     }
 }

--- a/InputMetrics/InputMetrics/Views/SettingsView.swift
+++ b/InputMetrics/InputMetrics/Views/SettingsView.swift
@@ -31,6 +31,8 @@ struct SettingsView: View {
     @State private var showResetConfirmation = false
     @State private var exportResult: ExportResult?
     @State private var showExportToast = false
+    @State private var databaseSize: String = "Calculating..."
+    @State private var totalRecords: Int = 0
 
     var body: some View {
         ZStack {
@@ -97,6 +99,64 @@ struct SettingsView: View {
                                 }
                                 .pickerStyle(.segmented)
                                 .labelsHidden()
+                            }
+                        }
+                    }
+
+                    // Storage Section
+                    SettingsSectionView(title: "Storage", icon: "internaldrive") {
+                        VStack(spacing: 0) {
+                            SettingsRowView {
+                                VStack(alignment: .leading, spacing: 12) {
+                                    Label("Data retention", systemImage: "clock.arrow.circlepath")
+                                        .font(.body)
+
+                                    Picker("", selection: $preferences.dataRetentionPeriod) {
+                                        ForEach(DataRetentionPeriod.allCases) { period in
+                                            Text(period.displayName).tag(period)
+                                        }
+                                    }
+                                    .pickerStyle(.segmented)
+                                    .labelsHidden()
+                                    .onChange(of: preferences.dataRetentionPeriod) { _, newValue in
+                                        if let days = newValue.days {
+                                            DatabaseManager.shared.pruneOldData(olderThanDays: days)
+                                            refreshDatabaseInfo()
+                                        }
+                                    }
+
+                                    Text("Data older than the selected period is automatically deleted on app launch.")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+
+                            SettingsRowView {
+                                HStack {
+                                    Label("Database size", systemImage: "externaldrive")
+                                        .font(.body)
+
+                                    Spacer()
+
+                                    Text(databaseSize)
+                                        .font(.body)
+                                        .monospacedDigit()
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+
+                            SettingsRowView {
+                                HStack {
+                                    Label("Total records", systemImage: "number")
+                                        .font(.body)
+
+                                    Spacer()
+
+                                    Text("\(totalRecords)")
+                                        .font(.body)
+                                        .monospacedDigit()
+                                        .foregroundStyle(.secondary)
+                                }
                             }
                         }
                     }
@@ -217,6 +277,9 @@ struct SettingsView: View {
         } message: {
             Text("This will permanently delete all tracking data. This action cannot be undone.")
         }
+        .onAppear {
+            refreshDatabaseInfo()
+        }
         .onChange(of: exportResult?.message) { oldValue, newValue in
             if newValue != nil {
                 withAnimation(.spring(response: 0.4, dampingFraction: 0.7)) {
@@ -320,6 +383,22 @@ struct SettingsView: View {
         MouseTracker.shared.reset()
         KeyboardTracker.shared.reset()
         exportResult = .success("All data has been reset")
+        refreshDatabaseInfo()
+    }
+
+    private func refreshDatabaseInfo() {
+        let sizeBytes = DatabaseManager.shared.getDatabaseFileSize()
+        databaseSize = formatFileSize(sizeBytes)
+
+        let counts = DatabaseManager.shared.getRecordCounts()
+        totalRecords = counts.dailySummaries + counts.mouseHeatmap + counts.keyboardHeatmap + counts.hourlySummaries
+    }
+
+    private func formatFileSize(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useKB, .useMB, .useGB]
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: bytes)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add DataRetentionPeriod enum with options: 3 months, 6 months, 1 year, forever (default)
- Store retention preference in UserPreferences via UserDefaults
- Add pruneOldData(olderThanDays:) to DatabaseManager that deletes old records from all four tables and vacuums the database
- Run cleanup automatically on app launch in AppDelegate
- Add new Storage section in Settings showing data retention picker, current database size, and total record count
- Prune immediately when the user changes the retention period

Closes #14

## Test plan
- Launch app and verify old data is pruned according to the selected retention period
- Open Settings and confirm the Storage section displays database size and total records
- Change retention period and verify data is pruned and stats refresh
- Set retention to Forever and confirm no data is deleted
- Reset all data and verify database size and record count update

Generated with [Claude Code](https://claude.com/claude-code)