### PR TITLE
test: Add unit tests for DistanceConverter and KeyCodeMapping

### DIFF
--- a/InputMetrics.xcodeproj/project.pbxproj
+++ b/InputMetrics.xcodeproj/project.pbxproj
@@ -11,8 +11,19 @@
 		LAUNCH_PKG /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = LAUNCH_REF /* LaunchAtLogin */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		TEST_CONTAINER_PROXY /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = PROJECT /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = APP_TARGET;
+			remoteInfo = InputMetrics;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		APP_PRODUCT /* InputMetrics.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InputMetrics.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		TEST_PRODUCT /* InputMetricsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InputMetricsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -34,6 +45,11 @@
 			path = InputMetrics/InputMetrics;
 			sourceTree = "<group>";
 		};
+		TEST_SOURCE_ROOT /* InputMetricsTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = InputMetricsTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -46,6 +62,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		TEST_FRAMEWORKS_PHASE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -53,6 +76,7 @@
 			isa = PBXGroup;
 			children = (
 				APP_PRODUCT /* InputMetrics.app */,
+				TEST_PRODUCT /* InputMetricsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -61,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				SOURCE_ROOT /* InputMetrics/InputMetrics */,
+				TEST_SOURCE_ROOT /* InputMetricsTests */,
 				PRODUCTS_GROUP /* Products */,
 			);
 			sourceTree = "<group>";
@@ -92,6 +117,27 @@
 			productReference = APP_PRODUCT /* InputMetrics.app */;
 			productType = "com.apple.product-type.application";
 		};
+		TEST_TARGET /* InputMetricsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = TEST_CONFIG_LIST /* Build configuration list for PBXNativeTarget "InputMetricsTests" */;
+			buildPhases = (
+				TEST_SOURCES_PHASE /* Sources */,
+				TEST_FRAMEWORKS_PHASE /* Frameworks */,
+				TEST_RESOURCES_PHASE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TEST_TARGET_DEPENDENCY /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				TEST_SOURCE_ROOT /* InputMetricsTests */,
+			);
+			name = InputMetricsTests;
+			productName = InputMetricsTests;
+			productReference = TEST_PRODUCT /* InputMetricsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -121,12 +167,20 @@
 			projectRoot = "";
 			targets = (
 				APP_TARGET /* InputMetrics */,
+				TEST_TARGET /* InputMetricsTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		RESOURCES_PHASE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		TEST_RESOURCES_PHASE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -143,7 +197,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		TEST_SOURCES_PHASE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		TEST_TARGET_DEPENDENCY /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = APP_TARGET /* InputMetrics */;
+			targetProxy = TEST_CONTAINER_PROXY /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		DEBUG_CONFIG /* Debug */ = {
@@ -328,6 +397,40 @@
 			};
 			name = Release;
 		};
+		TEST_DEBUG_CONFIG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.inputmetrics.InputMetricsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/InputMetrics.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/InputMetrics";
+			};
+			name = Debug;
+		};
+		TEST_RELEASE_CONFIG /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.inputmetrics.InputMetricsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/InputMetrics.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/InputMetrics";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -345,6 +448,15 @@
 			buildConfigurations = (
 				DEBUG_CONFIG /* Debug */,
 				RELEASE_CONFIG /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		TEST_CONFIG_LIST /* Build configuration list for PBXNativeTarget "InputMetricsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				TEST_DEBUG_CONFIG /* Debug */,
+				TEST_RELEASE_CONFIG /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/InputMetricsTests/DistanceConverterTests.swift
+++ b/InputMetricsTests/DistanceConverterTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import InputMetrics
+
+final class DistanceConverterTests: XCTestCase {
+
+    // MARK: - pixelsToMeters
+
+    func testPixelsToMetersZero() {
+        XCTAssertEqual(DistanceConverter.pixelsToMeters(0), 0)
+    }
+
+    func testPixelsToMetersKnownValue() {
+        // 4330 pixels = 1 meter (Constants.pixelsPerMeter)
+        XCTAssertEqual(DistanceConverter.pixelsToMeters(4330), 1.0, accuracy: 0.001)
+    }
+
+    func testPixelsToMetersLargeValue() {
+        let pixels = 43300.0
+        XCTAssertEqual(DistanceConverter.pixelsToMeters(pixels), 10.0, accuracy: 0.001)
+    }
+
+    // MARK: - metersToKilometers
+
+    func testMetersToKilometersZero() {
+        XCTAssertEqual(DistanceConverter.metersToKilometers(0), 0)
+    }
+
+    func testMetersToKilometersKnownValue() {
+        XCTAssertEqual(DistanceConverter.metersToKilometers(1000), 1.0, accuracy: 0.001)
+    }
+
+    func testMetersToKilometersFractional() {
+        XCTAssertEqual(DistanceConverter.metersToKilometers(500), 0.5, accuracy: 0.001)
+    }
+
+    // MARK: - metersToFeet
+
+    func testMetersToFeetZero() {
+        XCTAssertEqual(DistanceConverter.metersToFeet(0), 0)
+    }
+
+    func testMetersToFeetOneMeter() {
+        // 1 meter = 1 / 0.3048 feet ~ 3.28084 feet
+        XCTAssertEqual(DistanceConverter.metersToFeet(1.0), 3.28084, accuracy: 0.001)
+    }
+
+    // MARK: - feetToMiles
+
+    func testFeetToMilesZero() {
+        XCTAssertEqual(DistanceConverter.feetToMiles(0), 0)
+    }
+
+    func testFeetToMilesOneMile() {
+        XCTAssertEqual(DistanceConverter.feetToMiles(5280), 1.0, accuracy: 0.001)
+    }
+
+    // MARK: - formatDistance (metric)
+
+    func testFormatDistanceMetricMeters() {
+        // Small distance: should show meters
+        let pixels = 4330.0 * 500 // 500 meters
+        let result = DistanceConverter.formatDistance(pixels, unit: .metric)
+        XCTAssertEqual(result, "500.0 m")
+    }
+
+    func testFormatDistanceMetricKilometers() {
+        // Large distance: should show kilometers
+        let pixels = 4330.0 * 1500 // 1500 meters = 1.5 km
+        let result = DistanceConverter.formatDistance(pixels, unit: .metric)
+        XCTAssertEqual(result, "1.50 km")
+    }
+
+    func testFormatDistanceMetricThreshold() {
+        // Exactly 1000 meters should switch to km
+        let pixels = 4330.0 * 1000
+        let result = DistanceConverter.formatDistance(pixels, unit: .metric)
+        XCTAssertEqual(result, "1.00 km")
+    }
+
+    func testFormatDistanceMetricBelowThreshold() {
+        // 999 meters stays in meters
+        let pixels = 4330.0 * 999
+        let result = DistanceConverter.formatDistance(pixels, unit: .metric)
+        XCTAssertTrue(result.hasSuffix(" m"))
+    }
+
+    func testFormatDistanceDefaultsToMetric() {
+        let pixels = 4330.0 * 100
+        let result = DistanceConverter.formatDistance(pixels)
+        XCTAssertTrue(result.hasSuffix(" m"))
+    }
+
+    // MARK: - formatDistance (imperial)
+
+    func testFormatDistanceImperialFeet() {
+        // Small distance: should show feet
+        let pixels = 4330.0 * 100 // 100 meters ~ 328 feet
+        let result = DistanceConverter.formatDistance(pixels, unit: .imperial)
+        XCTAssertTrue(result.hasSuffix(" ft"))
+    }
+
+    func testFormatDistanceImperialMiles() {
+        // Large distance: should show miles
+        let pixels = 4330.0 * 5000 // 5000 meters ~ 3.1 miles
+        let result = DistanceConverter.formatDistance(pixels, unit: .imperial)
+        XCTAssertTrue(result.hasSuffix(" mi"))
+    }
+
+    // MARK: - formatDistance zero
+
+    func testFormatDistanceZero() {
+        let result = DistanceConverter.formatDistance(0, unit: .metric)
+        XCTAssertEqual(result, "0.0 m")
+    }
+
+    // MARK: - percentAroundEarth
+
+    func testPercentAroundEarthZero() {
+        XCTAssertEqual(DistanceConverter.percentAroundEarth(0), 0)
+    }
+
+    func testPercentAroundEarthKnownValue() {
+        // Earth circumference = 40,075,000 meters
+        // pixelsPerMeter = 4330
+        let earthPixels = 40_075_000.0 * 4330.0
+        XCTAssertEqual(DistanceConverter.percentAroundEarth(earthPixels), 100.0, accuracy: 0.001)
+    }
+
+    // MARK: - percentToMoon
+
+    func testPercentToMoonZero() {
+        XCTAssertEqual(DistanceConverter.percentToMoon(0), 0)
+    }
+
+    func testPercentToMoonKnownValue() {
+        // Moon distance = 384,400,000 meters
+        let moonPixels = 384_400_000.0 * 4330.0
+        XCTAssertEqual(DistanceConverter.percentToMoon(moonPixels), 100.0, accuracy: 0.001)
+    }
+
+    // MARK: - formatEarthComparison
+
+    func testFormatEarthComparisonContainsPercentSign() {
+        let result = DistanceConverter.formatEarthComparison(4330.0 * 100)
+        XCTAssertTrue(result.contains("%"))
+        XCTAssertTrue(result.contains("around the world"))
+    }
+
+    // MARK: - formatMoonComparison
+
+    func testFormatMoonComparisonContainsPercentSign() {
+        let result = DistanceConverter.formatMoonComparison(4330.0 * 100)
+        XCTAssertTrue(result.contains("%"))
+        XCTAssertTrue(result.contains("to the moon"))
+    }
+}

--- a/InputMetricsTests/KeyCodeMappingTests.swift
+++ b/InputMetricsTests/KeyCodeMappingTests.swift
@@ -1,0 +1,191 @@
+import XCTest
+import Carbon.HIToolbox
+@testable import InputMetrics
+
+final class KeyCodeMappingTests: XCTestCase {
+
+    // MARK: - Number row
+
+    func testNumberKeys() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_1), "1")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_2), "2")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_3), "3")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_4), "4")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_5), "5")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_6), "6")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_7), "7")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_8), "8")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_9), "9")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_0), "0")
+    }
+
+    func testGraveKey() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Grave), "^")
+    }
+
+    func testMinusKey() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Minus), "\u{00DF}") // ß
+    }
+
+    func testEqualKey() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Equal), "\u{00B4}") // ´
+    }
+
+    // MARK: - QWERTZ letter keys
+
+    func testTopRowLetters() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Q), "Q")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_W), "W")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_E), "E")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_R), "R")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_T), "T")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_U), "U")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_I), "I")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_O), "O")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_P), "P")
+    }
+
+    func testQwertzYZSwap() {
+        // kVK_ANSI_Y (physical Y position) maps to "Z" in QWERTZ
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Y), "Z")
+        // kVK_ANSI_Z (physical Z position) maps to "Y" in QWERTZ
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Z), "Y")
+    }
+
+    func testMiddleRowLetters() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_A), "A")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_S), "S")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_D), "D")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_F), "F")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_G), "G")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_H), "H")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_J), "J")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_K), "K")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_L), "L")
+    }
+
+    func testGermanUmlauts() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_LeftBracket), "\u{00DC}") // Ü
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Semicolon), "\u{00D6}") // Ö
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Quote), "\u{00C4}") // Ä
+    }
+
+    func testBottomRowLetters() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_X), "X")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_C), "C")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_V), "V")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_B), "B")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_N), "N")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_M), "M")
+    }
+
+    func testPunctuationKeys() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Comma), ",")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Period), ".")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Slash), "-")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_RightBracket), "+")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_ANSI_Backslash), "'")
+    }
+
+    // MARK: - Special keys
+
+    func testSpecialKeys() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_Space), "Space")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_Return), "\u{21B5}") // ↵
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_Tab), "\u{21E5}") // ⇥
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_Delete), "\u{232B}") // ⌫
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_Escape), "\u{238B}") // ⎋
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_CapsLock), "\u{21EA}") // ⇪
+    }
+
+    // MARK: - Modifier keys
+
+    func testModifierKeys() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_Shift), "\u{21E7}") // ⇧
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_RightShift), "\u{21E7}") // ⇧
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_Control), "\u{2303}") // ⌃
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_RightControl), "\u{2303}") // ⌃
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_Option), "\u{2325}") // ⌥
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_RightOption), "\u{2325}") // ⌥
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_Command), "\u{2318}") // ⌘
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_RightCommand), "\u{2318}") // ⌘
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_Function), "fn")
+    }
+
+    func testLeftAndRightModifiersMatch() {
+        XCTAssertEqual(
+            KeyCodeMapping.keyName(for: kVK_Shift),
+            KeyCodeMapping.keyName(for: kVK_RightShift)
+        )
+        XCTAssertEqual(
+            KeyCodeMapping.keyName(for: kVK_Control),
+            KeyCodeMapping.keyName(for: kVK_RightControl)
+        )
+        XCTAssertEqual(
+            KeyCodeMapping.keyName(for: kVK_Option),
+            KeyCodeMapping.keyName(for: kVK_RightOption)
+        )
+        XCTAssertEqual(
+            KeyCodeMapping.keyName(for: kVK_Command),
+            KeyCodeMapping.keyName(for: kVK_RightCommand)
+        )
+    }
+
+    // MARK: - Arrow keys
+
+    func testArrowKeys() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_LeftArrow), "\u{2190}") // ←
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_RightArrow), "\u{2192}") // →
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_UpArrow), "\u{2191}") // ↑
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_DownArrow), "\u{2193}") // ↓
+    }
+
+    // MARK: - Function keys
+
+    func testFunctionKeys() {
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F1), "F1")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F2), "F2")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F3), "F3")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F4), "F4")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F5), "F5")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F6), "F6")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F7), "F7")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F8), "F8")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F9), "F9")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F10), "F10")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F11), "F11")
+        XCTAssertEqual(KeyCodeMapping.keyName(for: kVK_F12), "F12")
+    }
+
+    // MARK: - Unknown key code
+
+    func testUnknownKeyCodeReturnsFallback() {
+        let result = KeyCodeMapping.keyName(for: 999)
+        XCTAssertEqual(result, "Key999")
+    }
+
+    func testUnknownKeyCodeFormat() {
+        let result = KeyCodeMapping.keyName(for: 200)
+        XCTAssertTrue(result.hasPrefix("Key"))
+    }
+
+    // MARK: - QWERTZ layout structure
+
+    func testQwertzLayoutHasFiveRows() {
+        XCTAssertEqual(KeyCodeMapping.qwertzLayout.count, 5)
+    }
+
+    func testQwertzLayoutFirstRowStartsWithCaret() {
+        XCTAssertEqual(KeyCodeMapping.qwertzLayout[0].first, "^")
+    }
+
+    func testQwertzLayoutFirstRowEndsWithBackspace() {
+        XCTAssertEqual(KeyCodeMapping.qwertzLayout[0].last, "\u{232B}") // ⌫
+    }
+
+    func testQwertzLayoutContainsSpaceBar() {
+        let bottomRow = KeyCodeMapping.qwertzLayout[4]
+        let hasSpace = bottomRow.contains { $0.contains("Space") }
+        XCTAssertTrue(hasSpace)
+    }
+}


### PR DESCRIPTION
## Summary
- Add XCTest target `InputMetricsTests` to the Xcode project
- Add 24 unit tests for `DistanceConverter` covering pixel-to-meter conversion, metric/imperial formatting, threshold behavior, and earth/moon comparison functions
- Add 21 unit tests for `KeyCodeMapping` covering number keys, QWERTZ Y/Z swap, German umlauts, special keys, modifier keys, arrow keys, function keys, unknown key fallback, and layout structure
- All 45 tests pass

Closes #9

## Test plan
- Run `xcodebuild test -scheme InputMetrics -destination "platform=macOS"` to execute all tests
- Verify all 45 tests pass with 0 failures
- Open the project in Xcode and confirm the InputMetricsTests target appears in the scheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)