### PR TITLE
feat(tracking): Add scroll wheel distance tracking

### DIFF
--- a/InputMetrics/InputMetrics/Models/DailySummary.swift
+++ b/InputMetrics/InputMetrics/Models/DailySummary.swift
@@ -10,6 +10,8 @@ struct DailySummary: Codable, FetchableRecord, PersistableRecord {
     var mouseClicksRight: Int
     var mouseClicksMiddle: Int
     var keystrokes: Int
+    var scrollDistanceVertical: Double
+    var scrollDistanceHorizontal: Double
 
     enum CodingKeys: String, CodingKey {
         case date
@@ -18,6 +20,8 @@ struct DailySummary: Codable, FetchableRecord, PersistableRecord {
         case mouseClicksRight = "mouse_clicks_right"
         case mouseClicksMiddle = "mouse_clicks_middle"
         case keystrokes
+        case scrollDistanceVertical = "scroll_distance_vertical"
+        case scrollDistanceHorizontal = "scroll_distance_horizontal"
     }
 
     enum Columns {
@@ -27,5 +31,7 @@ struct DailySummary: Codable, FetchableRecord, PersistableRecord {
         static let mouseClicksRight = Column(CodingKeys.mouseClicksRight)
         static let mouseClicksMiddle = Column(CodingKeys.mouseClicksMiddle)
         static let keystrokes = Column(CodingKeys.keystrokes)
+        static let scrollDistanceVertical = Column(CodingKeys.scrollDistanceVertical)
+        static let scrollDistanceHorizontal = Column(CodingKeys.scrollDistanceHorizontal)
     }
 }

--- a/InputMetrics/InputMetrics/Services/DatabaseManager.swift
+++ b/InputMetrics/InputMetrics/Services/DatabaseManager.swift
@@ -51,6 +51,7 @@ final class DatabaseManager: @unchecked Sendable {
         registerV2Migration(&migrator)
         registerV3Migration(&migrator)
         registerV4Migration(&migrator)
+        registerV5Migration(&migrator)
 
         return migrator
     }
@@ -108,6 +109,15 @@ final class DatabaseManager: @unchecked Sendable {
         }
     }
 
+    private func registerV5Migration(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("v5") { db in
+            try db.alter(table: "daily_summary") { t in
+                t.add(column: "scroll_distance_vertical", .double).defaults(to: 0)
+                t.add(column: "scroll_distance_horizontal", .double).defaults(to: 0)
+            }
+        }
+    }
+
     // MARK: - Daily Summary Operations
 
     func updateDailySummary(
@@ -116,7 +126,9 @@ final class DatabaseManager: @unchecked Sendable {
         leftClicks: Int = 0,
         rightClicks: Int = 0,
         middleClicks: Int = 0,
-        keystrokes: Int = 0
+        keystrokes: Int = 0,
+        scrollVertical: Double = 0,
+        scrollHorizontal: Double = 0
     ) {
         guard let db = dbQueue else { return }
 
@@ -125,16 +137,18 @@ final class DatabaseManager: @unchecked Sendable {
                 try db.write { db in
                     try db.execute(
                         sql: """
-                            INSERT INTO daily_summary (date, mouse_distance_px, mouse_clicks_left, mouse_clicks_right, mouse_clicks_middle, keystrokes)
-                            VALUES (?, ?, ?, ?, ?, ?)
+                            INSERT INTO daily_summary (date, mouse_distance_px, mouse_clicks_left, mouse_clicks_right, mouse_clicks_middle, keystrokes, scroll_distance_vertical, scroll_distance_horizontal)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                             ON CONFLICT(date) DO UPDATE SET
                                 mouse_distance_px = mouse_distance_px + excluded.mouse_distance_px,
                                 mouse_clicks_left = mouse_clicks_left + excluded.mouse_clicks_left,
                                 mouse_clicks_right = mouse_clicks_right + excluded.mouse_clicks_right,
                                 mouse_clicks_middle = mouse_clicks_middle + excluded.mouse_clicks_middle,
-                                keystrokes = keystrokes + excluded.keystrokes
+                                keystrokes = keystrokes + excluded.keystrokes,
+                                scroll_distance_vertical = scroll_distance_vertical + excluded.scroll_distance_vertical,
+                                scroll_distance_horizontal = scroll_distance_horizontal + excluded.scroll_distance_horizontal
                             """,
-                        arguments: [date, mouseDistance, leftClicks, rightClicks, middleClicks, keystrokes]
+                        arguments: [date, mouseDistance, leftClicks, rightClicks, middleClicks, keystrokes, scrollVertical, scrollHorizontal]
                     )
                 }
             } catch {
@@ -415,8 +429,10 @@ final class DatabaseManager: @unchecked Sendable {
         var clicksRight: Int
         var clicksMiddle: Int
         var keystrokes: Int
+        var scrollVertical: Double
+        var scrollHorizontal: Double
 
-        static let zero = AllTimeTotals(distance: 0, clicksLeft: 0, clicksRight: 0, clicksMiddle: 0, keystrokes: 0)
+        static let zero = AllTimeTotals(distance: 0, clicksLeft: 0, clicksRight: 0, clicksMiddle: 0, keystrokes: 0, scrollVertical: 0, scrollHorizontal: 0)
 
         var totalClicks: Int { clicksLeft + clicksRight + clicksMiddle }
     }
@@ -432,7 +448,9 @@ final class DatabaseManager: @unchecked Sendable {
                         COALESCE(SUM(mouse_clicks_left), 0) AS clicks_left,
                         COALESCE(SUM(mouse_clicks_right), 0) AS clicks_right,
                         COALESCE(SUM(mouse_clicks_middle), 0) AS clicks_middle,
-                        COALESCE(SUM(keystrokes), 0) AS keystrokes
+                        COALESCE(SUM(keystrokes), 0) AS keystrokes,
+                        COALESCE(SUM(scroll_distance_vertical), 0) AS scroll_vertical,
+                        COALESCE(SUM(scroll_distance_horizontal), 0) AS scroll_horizontal
                     FROM daily_summary
                     """)
                 guard let row else { return .zero }
@@ -441,7 +459,9 @@ final class DatabaseManager: @unchecked Sendable {
                     clicksLeft: row["clicks_left"],
                     clicksRight: row["clicks_right"],
                     clicksMiddle: row["clicks_middle"],
-                    keystrokes: row["keystrokes"]
+                    keystrokes: row["keystrokes"],
+                    scrollVertical: row["scroll_vertical"],
+                    scrollHorizontal: row["scroll_horizontal"]
                 )
             }
         } catch {

--- a/InputMetrics/InputMetrics/Services/EventMonitor.swift
+++ b/InputMetrics/InputMetrics/Services/EventMonitor.swift
@@ -37,7 +37,8 @@ class EventMonitor {
                        (1 << CGEventType.leftMouseDown.rawValue) |
                        (1 << CGEventType.rightMouseDown.rawValue) |
                        (1 << CGEventType.otherMouseDown.rawValue) |
-                       (1 << CGEventType.keyDown.rawValue)
+                       (1 << CGEventType.keyDown.rawValue) |
+                       (1 << CGEventType.scrollWheel.rawValue)
 
         guard let eventTap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
@@ -83,6 +84,8 @@ class EventMonitor {
         let location = event.location
         let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
         let flags = event.flags
+        let scrollDeltaY = event.getDoubleValueField(.scrollWheelEventPointDeltaAxis1)
+        let scrollDeltaX = event.getDoubleValueField(.scrollWheelEventPointDeltaAxis2)
 
         // The event tap callback runs on the main thread's run loop, so we
         // can dispatch synchronously via assumeIsolated instead of spawning
@@ -104,6 +107,9 @@ class EventMonitor {
 
             case .keyDown:
                 KeyboardTracker.shared.trackKeystroke(keyCode: keyCode, modifierFlags: flags)
+
+            case .scrollWheel:
+                MouseTracker.shared.trackScroll(deltaX: scrollDeltaX, deltaY: scrollDeltaY)
 
             default:
                 break

--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -22,6 +22,8 @@ class MouseTracker {
     private var leftClicks: Int = 0
     private var rightClicks: Int = 0
     private var middleClicks: Int = 0
+    private var scrollVertical: Double = 0
+    private var scrollHorizontal: Double = 0
 
     private var heatmapBuffer: [HeatmapBucketKey: Int] = [:]
 
@@ -124,6 +126,11 @@ class MouseTracker {
         heatmapBuffer[key, default: 0] += 1
     }
 
+    func trackScroll(deltaX: Double, deltaY: Double) {
+        scrollVertical += abs(deltaY)
+        scrollHorizontal += abs(deltaX)
+    }
+
     private func setupPersistTimer() {
         persistTimer = Timer.scheduledTimer(withTimeInterval: persistInterval, repeats: true) { [weak self] _ in
             Task { @MainActor in
@@ -141,7 +148,9 @@ class MouseTracker {
             mouseDistance: accumulatedDistance,
             leftClicks: leftClicks,
             rightClicks: rightClicks,
-            middleClicks: middleClicks
+            middleClicks: middleClicks,
+            scrollVertical: scrollVertical,
+            scrollHorizontal: scrollHorizontal
         )
 
         DatabaseManager.shared.updateHourlySummary(
@@ -160,15 +169,19 @@ class MouseTracker {
         let persistedLeft = leftClicks
         let persistedRight = rightClicks
         let persistedMiddle = middleClicks
+        let persistedScrollV = scrollVertical
+        let persistedScrollH = scrollHorizontal
         let persistedHeatmapBuckets = heatmapBuffer.count
 
         accumulatedDistance = 0
         leftClicks = 0
         rightClicks = 0
         middleClicks = 0
+        scrollVertical = 0
+        scrollHorizontal = 0
         heatmapBuffer.removeAll()
 
-        print("Mouse data persisted: \(persistedDistance)px, L:\(persistedLeft) R:\(persistedRight) M:\(persistedMiddle), heatmap buckets:\(persistedHeatmapBuckets)")
+        print("Mouse data persisted: \(persistedDistance)px, L:\(persistedLeft) R:\(persistedRight) M:\(persistedMiddle) SV:\(persistedScrollV) SH:\(persistedScrollH), heatmap buckets:\(persistedHeatmapBuckets)")
     }
 
     func reset() {
@@ -176,12 +189,14 @@ class MouseTracker {
         leftClicks = 0
         rightClicks = 0
         middleClicks = 0
+        scrollVertical = 0
+        scrollHorizontal = 0
         lastPoint = nil
         heatmapBuffer.removeAll()
     }
 
-    func getCurrentStats() -> (distance: Double, left: Int, right: Int, middle: Int) {
-        return (accumulatedDistance, leftClicks, rightClicks, middleClicks)
+    func getCurrentStats() -> (distance: Double, left: Int, right: Int, middle: Int, scrollV: Double, scrollH: Double) {
+        return (accumulatedDistance, leftClicks, rightClicks, middleClicks, scrollVertical, scrollHorizontal)
     }
 
     private func bucketForPoint(_ point: CGPoint) -> (x: Int, y: Int) {

--- a/InputMetrics/InputMetrics/Views/ChartView.swift
+++ b/InputMetrics/InputMetrics/Views/ChartView.swift
@@ -89,9 +89,9 @@ struct ChartView: View {
 #Preview {
     ChartView(
         data: [
-            DailySummary(date: "2025-01-10", mouseDistancePx: 5000000, mouseClicksLeft: 100, mouseClicksRight: 20, mouseClicksMiddle: 5, keystrokes: 2000),
-            DailySummary(date: "2025-01-11", mouseDistancePx: 7000000, mouseClicksLeft: 150, mouseClicksRight: 30, mouseClicksMiddle: 8, keystrokes: 3000),
-            DailySummary(date: "2025-01-12", mouseDistancePx: 4000000, mouseClicksLeft: 80, mouseClicksRight: 15, mouseClicksMiddle: 3, keystrokes: 1500)
+            DailySummary(date: "2025-01-10", mouseDistancePx: 5000000, mouseClicksLeft: 100, mouseClicksRight: 20, mouseClicksMiddle: 5, keystrokes: 2000, scrollDistanceVertical: 0, scrollDistanceHorizontal: 0),
+            DailySummary(date: "2025-01-11", mouseDistancePx: 7000000, mouseClicksLeft: 150, mouseClicksRight: 30, mouseClicksMiddle: 8, keystrokes: 3000, scrollDistanceVertical: 0, scrollDistanceHorizontal: 0),
+            DailySummary(date: "2025-01-12", mouseDistancePx: 4000000, mouseClicksLeft: 80, mouseClicksRight: 15, mouseClicksMiddle: 3, keystrokes: 1500, scrollDistanceVertical: 0, scrollDistanceHorizontal: 0)
         ],
         range: .week
     )

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -13,9 +13,13 @@ struct MenuBarView: View {
     @State private var chartData: [DailySummary] = []
     @State private var heatmapData: [[Int]] = []
     @State private var keyboardEntries: [KeyboardEntry] = []
+    @State private var scrollVertical: Double = 0
+    @State private var scrollHorizontal: Double = 0
     @State private var allTimeDistance: Double = 0
     @State private var allTimeClicks: Int = 0
     @State private var allTimeKeystrokes: Int = 0
+    @State private var allTimeScrollVertical: Double = 0
+    @State private var allTimeScrollHorizontal: Double = 0
     @State private var cachedTotals: DatabaseManager.AllTimeTotals = .zero
     @State private var lastCacheTime: Date = .distantPast
 
@@ -88,7 +92,7 @@ struct MenuBarView: View {
 
     private var mouseMetricsView: some View {
         VStack(spacing: 16) {
-            // Distance and Clicks Cards - equal width grid
+            // Distance, Clicks, and Scroll Cards
             LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
                 // Distance Card
                 VStack(alignment: .leading, spacing: 8) {
@@ -118,6 +122,30 @@ struct MenuBarView: View {
                         .font(.title.bold())
 
                     Text("Clicks")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                .padding()
+                .background(Color.secondary.opacity(0.1))
+                .cornerRadius(12)
+
+                // Scroll Card
+                VStack(alignment: .leading, spacing: 8) {
+                    Image(systemName: "scroll")
+                        .font(.title2)
+                        .foregroundStyle(.orange)
+
+                    let totalScroll = scrollVertical + scrollHorizontal
+                    if totalScroll < 1000 {
+                        Text(String(format: "%.0f px", totalScroll))
+                            .font(.title.bold())
+                    } else {
+                        Text(String(format: "%.1f K", totalScroll / 1000))
+                            .font(.title.bold())
+                    }
+
+                    Text("Scroll")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -311,6 +339,26 @@ struct MenuBarView: View {
                 .padding()
                 .background(Color.purple.opacity(0.1))
                 .cornerRadius(12)
+
+                // Total Scroll
+                VStack(alignment: .leading, spacing: 4) {
+                    Label("Scroll", systemImage: "scroll")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    let totalScroll = allTimeScrollVertical + allTimeScrollHorizontal
+                    if totalScroll < 1000 {
+                        Text(String(format: "%.0f px", totalScroll))
+                            .font(.title2.bold().monospacedDigit())
+                    } else {
+                        Text(String(format: "%.1f K px", totalScroll / 1000))
+                            .font(.title2.bold().monospacedDigit())
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                .background(Color.orange.opacity(0.1))
+                .cornerRadius(12)
             }
             .padding(.horizontal)
         }
@@ -327,12 +375,16 @@ struct MenuBarView: View {
             leftClicks = summary.mouseClicksLeft + mouseStats.left
             rightClicks = summary.mouseClicksRight + mouseStats.right
             middleClicks = summary.mouseClicksMiddle + mouseStats.middle
+            scrollVertical = summary.scrollDistanceVertical + mouseStats.scrollV
+            scrollHorizontal = summary.scrollDistanceHorizontal + mouseStats.scrollH
         } else {
             mouseDistance = mouseStats.distance
             keystrokes = keyboardStats
             leftClicks = mouseStats.left
             rightClicks = mouseStats.right
             middleClicks = mouseStats.middle
+            scrollVertical = mouseStats.scrollV
+            scrollHorizontal = mouseStats.scrollH
         }
     }
 
@@ -385,6 +437,8 @@ struct MenuBarView: View {
         allTimeDistance = cachedTotals.distance + mouseStats.distance
         allTimeClicks = cachedTotals.totalClicks + mouseStats.left + mouseStats.right + mouseStats.middle
         allTimeKeystrokes = cachedTotals.keystrokes + KeyboardTracker.shared.getCurrentKeystrokes()
+        allTimeScrollVertical = cachedTotals.scrollVertical + mouseStats.scrollV
+        allTimeScrollHorizontal = cachedTotals.scrollHorizontal + mouseStats.scrollH
     }
 
     private func chartDistance(_ pixels: Double) -> Double {

--- a/InputMetrics/InputMetrics/Views/MouseStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/MouseStatsView.swift
@@ -54,6 +54,7 @@ struct MouseStatsView: View {
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Distance: \(DistanceConverter.formatDistance(stats.mouseDistancePx))")
                             Text("Clicks: \(stats.mouseClicksLeft + stats.mouseClicksRight + stats.mouseClicksMiddle)")
+                            Text("Scroll: \(formatScrollDistance(vertical: stats.scrollDistanceVertical, horizontal: stats.scrollDistanceHorizontal))")
                             Text("Keystrokes: \(stats.keystrokes)")
 
                             Divider()
@@ -101,6 +102,15 @@ struct MouseStatsView: View {
         chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
     }
 
+    private func formatScrollDistance(vertical: Double, horizontal: Double) -> String {
+        let total = vertical + horizontal
+        if total < 1000 {
+            return String(format: "%.0f px", total)
+        } else {
+            return String(format: "%.1f K px", total / 1000)
+        }
+    }
+
     private func loadAllTimeStats() {
         let totals = DatabaseManager.shared.getAllTimeTotals()
 
@@ -110,7 +120,9 @@ struct MouseStatsView: View {
             mouseClicksLeft: totals.clicksLeft,
             mouseClicksRight: totals.clicksRight,
             mouseClicksMiddle: totals.clicksMiddle,
-            keystrokes: totals.keystrokes
+            keystrokes: totals.keystrokes,
+            scrollDistanceVertical: totals.scrollVertical,
+            scrollDistanceHorizontal: totals.scrollHorizontal
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add scrollWheel to the CGEvent tap mask in EventMonitor to capture scroll events
- Accumulate vertical and horizontal scroll deltas in MouseTracker (absolute pixel distance)
- Add scroll_distance_vertical and scroll_distance_horizontal columns to daily_summary via a v2 database migration
- Display scroll distance in both MenuBarView (today + all-time cards) and MouseStatsView (all-time stats)

Closes #12

## Test plan
- Launch the app with accessibility permissions enabled
- Scroll using a mouse wheel or trackpad in any application
- Verify the Scroll card in the menu bar popover increments in real time
- Wait 30 seconds for persist and verify the value survives an app restart
- Check the All Time section shows accumulated scroll distance
- Open the dashboard and verify scroll appears in the all-time stats panel
- Test horizontal scrolling (shift+scroll or trackpad swipe) and confirm it is tracked separately

Generated with [Claude Code](https://claude.com/claude-code)