### PR TITLE
refactor: Extract ViewModel layer from views

### DIFF
--- a/InputMetrics/InputMetrics/Models/TimeRange.swift
+++ b/InputMetrics/InputMetrics/Models/TimeRange.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum TimeRange {
+    case week
+    case month
+    case year
+}

--- a/InputMetrics/InputMetrics/ViewModels/KeyboardStatsViewModel.swift
+++ b/InputMetrics/InputMetrics/ViewModels/KeyboardStatsViewModel.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class KeyboardStatsViewModel {
+    var selectedRange: TimeRange = .week
+    var chartData: [DailySummary] = []
+    var keyboardEntries: [KeyboardEntry] = []
+
+    var topKeys: [(id: String, name: String, count: Int)] {
+        let sorted = keyboardEntries.sorted { $0.count > $1.count }
+        return Array(sorted.prefix(5)).map { ($0.compositeId, KeyCodeMapping.keyName(for: $0.keyCode), $0.count) }
+    }
+
+    func loadAll() {
+        loadChartData()
+        loadKeyboardData()
+    }
+
+    func onRangeChanged() {
+        loadChartData()
+    }
+
+    func loadChartData() {
+        let calendar = Calendar.current
+        let today = Date()
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        let daysBack: Int
+        switch selectedRange {
+        case .week: daysBack = 7
+        case .month: daysBack = 30
+        case .year: daysBack = 365
+        }
+
+        guard let startDate = calendar.date(byAdding: .day, value: -daysBack, to: today) else { return }
+
+        let startString = formatter.string(from: startDate)
+        let endString = formatter.string(from: today)
+
+        chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
+    }
+
+    func loadKeyboardData() {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        let today = formatter.string(from: Date())
+
+        keyboardEntries = DatabaseManager.shared.getKeyboardEntries(date: today)
+    }
+}

--- a/InputMetrics/InputMetrics/ViewModels/MenuBarViewModel.swift
+++ b/InputMetrics/InputMetrics/ViewModels/MenuBarViewModel.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class MenuBarViewModel {
+    enum MetricTab {
+        case mouse, keyboard
+    }
+
+    var selectedTab: MetricTab = .mouse
+    var mouseDistance: Double = 0
+    var keystrokes: Int = 0
+    var leftClicks: Int = 0
+    var rightClicks: Int = 0
+    var middleClicks: Int = 0
+    var chartData: [DailySummary] = []
+    var heatmapData: [[Int]] = []
+    var keyboardEntries: [KeyboardEntry] = []
+    var scrollVertical: Double = 0
+    var scrollHorizontal: Double = 0
+    var allTimeDistance: Double = 0
+    var allTimeClicks: Int = 0
+    var allTimeKeystrokes: Int = 0
+    var allTimeScrollVertical: Double = 0
+    var allTimeScrollHorizontal: Double = 0
+    private var cachedTotals: DatabaseManager.AllTimeTotals = .zero
+    private var lastCacheTime: Date = .distantPast
+    private let cacheInterval: TimeInterval = 30
+
+    var totalClicks: Int {
+        leftClicks + rightClicks + middleClicks
+    }
+
+    var topKeys: [KeyboardEntry] {
+        Array(keyboardEntries.sorted { $0.count > $1.count }.prefix(5))
+    }
+
+    func loadAll() {
+        updateStats()
+        loadChartData()
+        loadHeatmapData()
+        loadKeyboardData()
+        refreshCachedTotals()
+        updateAllTimeStats()
+    }
+
+    func updateStats() {
+        let mouseStats = MouseTracker.shared.getCurrentStats()
+        let keyboardStats = KeyboardTracker.shared.getCurrentKeystrokes()
+        let today = todayString()
+
+        if let summary = DatabaseManager.shared.getDailySummary(date: today) {
+            mouseDistance = summary.mouseDistancePx + mouseStats.distance
+            keystrokes = summary.keystrokes + keyboardStats
+            leftClicks = summary.mouseClicksLeft + mouseStats.left
+            rightClicks = summary.mouseClicksRight + mouseStats.right
+            middleClicks = summary.mouseClicksMiddle + mouseStats.middle
+            scrollVertical = summary.scrollDistanceVertical + mouseStats.scrollV
+            scrollHorizontal = summary.scrollDistanceHorizontal + mouseStats.scrollH
+        } else {
+            mouseDistance = mouseStats.distance
+            keystrokes = keyboardStats
+            leftClicks = mouseStats.left
+            rightClicks = mouseStats.right
+            middleClicks = mouseStats.middle
+            scrollVertical = mouseStats.scrollV
+            scrollHorizontal = mouseStats.scrollH
+        }
+    }
+
+    func refreshCachedTotals() {
+        cachedTotals = DatabaseManager.shared.getAllTimeTotals()
+        lastCacheTime = Date()
+    }
+
+    func refreshAllTimeTotalsIfNeeded() {
+        guard Date().timeIntervalSince(lastCacheTime) >= cacheInterval else { return }
+        refreshCachedTotals()
+    }
+
+    func updateAllTimeStats() {
+        let mouseStats = MouseTracker.shared.getCurrentStats()
+        allTimeDistance = cachedTotals.distance + mouseStats.distance
+        allTimeClicks = cachedTotals.totalClicks + mouseStats.left + mouseStats.right + mouseStats.middle
+        allTimeKeystrokes = cachedTotals.keystrokes + KeyboardTracker.shared.getCurrentKeystrokes()
+        allTimeScrollVertical = cachedTotals.scrollVertical + mouseStats.scrollV
+        allTimeScrollHorizontal = cachedTotals.scrollHorizontal + mouseStats.scrollH
+    }
+
+    func loadChartData() {
+        let calendar = Calendar.current
+        let today = Date()
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        guard let startDate = calendar.date(byAdding: .day, value: -6, to: today) else { return }
+
+        let startString = formatter.string(from: startDate)
+        let endString = formatter.string(from: today)
+
+        chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
+    }
+
+    func loadHeatmapData() {
+        let today = todayString()
+        let entries = DatabaseManager.shared.getMouseHeatmap(date: today)
+
+        var grid = Array(repeating: Array(repeating: 0, count: 50), count: 50)
+
+        for entry in entries {
+            guard entry.bucketX >= 0 && entry.bucketY >= 0 && entry.bucketX < 50 && entry.bucketY < 50 else { continue }
+            grid[entry.bucketY][entry.bucketX] += entry.clickCount
+        }
+
+        heatmapData = grid
+    }
+
+    func loadKeyboardData() {
+        let today = todayString()
+        keyboardEntries = DatabaseManager.shared.getKeyboardEntries(date: today)
+    }
+
+    func chartDistance(_ pixels: Double, unit: DistanceUnit) -> Double {
+        let meters = DistanceConverter.pixelsToMeters(pixels)
+        if unit == .metric {
+            return DistanceConverter.metersToKilometers(meters)
+        } else {
+            let feet = DistanceConverter.metersToFeet(meters)
+            return DistanceConverter.feetToMiles(feet)
+        }
+    }
+
+    func shortDay(from dateString: String) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        guard let date = formatter.date(from: dateString) else { return "" }
+
+        formatter.dateFormat = "EEE"
+        return formatter.string(from: date)
+    }
+
+    private func todayString() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
+}

--- a/InputMetrics/InputMetrics/ViewModels/MouseStatsViewModel.swift
+++ b/InputMetrics/InputMetrics/ViewModels/MouseStatsViewModel.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class MouseStatsViewModel {
+    var selectedRange: TimeRange = .week
+    var chartData: [DailySummary] = []
+    var allTimeStats: DailySummary?
+
+    func loadAll() {
+        loadChartData()
+        loadAllTimeStats()
+    }
+
+    func onRangeChanged() {
+        loadChartData()
+    }
+
+    func loadChartData() {
+        let calendar = Calendar.current
+        let today = Date()
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        let daysBack: Int
+        switch selectedRange {
+        case .week: daysBack = 7
+        case .month: daysBack = 30
+        case .year: daysBack = 365
+        }
+
+        guard let startDate = calendar.date(byAdding: .day, value: -daysBack, to: today) else { return }
+
+        let startString = formatter.string(from: startDate)
+        let endString = formatter.string(from: today)
+
+        chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
+    }
+
+    func loadAllTimeStats() {
+        let totals = DatabaseManager.shared.getAllTimeTotals()
+
+        allTimeStats = DailySummary(
+            date: "",
+            mouseDistancePx: totals.distance,
+            mouseClicksLeft: totals.clicksLeft,
+            mouseClicksRight: totals.clicksRight,
+            mouseClicksMiddle: totals.clicksMiddle,
+            keystrokes: totals.keystrokes,
+            scrollDistanceVertical: totals.scrollVertical,
+            scrollDistanceHorizontal: totals.scrollHorizontal
+        )
+    }
+
+    func formatScrollDistance(vertical: Double, horizontal: Double) -> String {
+        let total = vertical + horizontal
+        if total < 1000 {
+            return String(format: "%.0f px", total)
+        } else {
+            return String(format: "%.1f K px", total / 1000)
+        }
+    }
+}

--- a/InputMetrics/InputMetrics/Views/KeyboardStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/KeyboardStatsView.swift
@@ -2,35 +2,33 @@ import SwiftUI
 import Charts
 
 struct KeyboardStatsView: View {
-    @State private var selectedRange: TimeRange = .week
-    @State private var chartData: [DailySummary] = []
-    @State private var keyboardEntries: [KeyboardEntry] = []
+    @State private var viewModel = KeyboardStatsViewModel()
 
     var body: some View {
         VStack(spacing: 20) {
             // Time range selector
             HStack {
                 Spacer()
-                Picker("Range", selection: $selectedRange) {
+                Picker("Range", selection: $viewModel.selectedRange) {
                     Text("Week").tag(TimeRange.week)
                     Text("Month").tag(TimeRange.month)
                     Text("Year").tag(TimeRange.year)
                 }
                 .pickerStyle(.segmented)
                 .frame(width: 250)
-                .onChange(of: selectedRange) { _, _ in
-                    loadChartData()
+                .onChange(of: viewModel.selectedRange) { _, _ in
+                    viewModel.onRangeChanged()
                 }
             }
             .padding(.horizontal)
 
             // Chart
-            ChartView(data: chartData, range: selectedRange, metric: .keystrokes)
+            ChartView(data: viewModel.chartData, range: viewModel.selectedRange, metric: .keystrokes)
                 .frame(height: 250)
                 .padding()
 
             // Keyboard heatmap
-            KeyboardHeatmapView(entries: keyboardEntries)
+            KeyboardHeatmapView(entries: viewModel.keyboardEntries)
                 .padding()
 
             // Top keys
@@ -39,7 +37,7 @@ struct KeyboardStatsView: View {
                     .font(.headline)
 
                 HStack(spacing: 12) {
-                    ForEach(topKeys(), id: \.id) { entry in
+                    ForEach(viewModel.topKeys, id: \.id) { entry in
                         Text("\(entry.name) (\(entry.count))")
                             .font(.caption)
                             .padding(.horizontal, 8)
@@ -52,45 +50,8 @@ struct KeyboardStatsView: View {
             .padding()
         }
         .onAppear {
-            loadChartData()
-            loadKeyboardData()
+            viewModel.loadAll()
         }
-    }
-
-    private func loadChartData() {
-        let calendar = Calendar.current
-        let today = Date()
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-
-        let daysBack: Int
-        switch selectedRange {
-        case .week: daysBack = 7
-        case .month: daysBack = 30
-        case .year: daysBack = 365
-        }
-
-        guard let startDate = calendar.date(byAdding: .day, value: -daysBack, to: today) else { return }
-
-        let startString = formatter.string(from: startDate)
-        let endString = formatter.string(from: today)
-
-        chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
-    }
-
-    private func loadKeyboardData() {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        let today = formatter.string(from: Date())
-
-        keyboardEntries = DatabaseManager.shared.getKeyboardEntries(date: today)
-    }
-
-    private func topKeys() -> [(id: String, name: String, count: Int)] {
-        let sorted = keyboardEntries.sorted { $0.count > $1.count }
-        return Array(sorted.prefix(5)).map { ($0.compositeId, KeyCodeMapping.keyName(for: $0.keyCode), $0.count) }
     }
 }
 

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -4,27 +4,9 @@ import Charts
 
 struct MenuBarView: View {
     @ObservedObject private var preferences = UserPreferences.shared
-    @State private var selectedTab: MetricTab = .mouse
-    @State private var mouseDistance: Double = 0
-    @State private var keystrokes: Int = 0
-    @State private var leftClicks: Int = 0
-    @State private var rightClicks: Int = 0
-    @State private var middleClicks: Int = 0
-    @State private var chartData: [DailySummary] = []
-    @State private var heatmapData: [[Int]] = []
-    @State private var keyboardEntries: [KeyboardEntry] = []
-    @State private var scrollVertical: Double = 0
-    @State private var scrollHorizontal: Double = 0
-    @State private var allTimeDistance: Double = 0
-    @State private var allTimeClicks: Int = 0
-    @State private var allTimeKeystrokes: Int = 0
-    @State private var allTimeScrollVertical: Double = 0
-    @State private var allTimeScrollHorizontal: Double = 0
-    @State private var cachedTotals: DatabaseManager.AllTimeTotals = .zero
-    @State private var lastCacheTime: Date = .distantPast
+    @State private var viewModel = MenuBarViewModel()
 
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
-    private let cacheInterval: TimeInterval = 30
 
     var body: some View {
         VStack(spacing: 0) {
@@ -40,9 +22,9 @@ struct MenuBarView: View {
 
                 Spacer()
 
-                Picker("Metric", selection: $selectedTab) {
-                    Text("Mouse Metrics").tag(MetricTab.mouse)
-                    Text("Keyboard Metrics").tag(MetricTab.keyboard)
+                Picker("Metric", selection: $viewModel.selectedTab) {
+                    Text("Mouse Metrics").tag(MenuBarViewModel.MetricTab.mouse)
+                    Text("Keyboard Metrics").tag(MenuBarViewModel.MetricTab.keyboard)
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
@@ -59,7 +41,7 @@ struct MenuBarView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal)
 
-                    if selectedTab == .mouse {
+                    if viewModel.selectedTab == .mouse {
                         mouseMetricsView
                     } else {
                         keyboardMetricsView
@@ -76,17 +58,12 @@ struct MenuBarView: View {
         }
         .frame(width: 420, height: 600)
         .onReceive(timer) { _ in
-            updateStats()
-            refreshAllTimeTotalsIfNeeded()
-            updateAllTimeStats()
+            viewModel.updateStats()
+            viewModel.refreshAllTimeTotalsIfNeeded()
+            viewModel.updateAllTimeStats()
         }
         .onAppear {
-            updateStats()
-            loadChartData()
-            loadHeatmapData()
-            loadKeyboardData()
-            refreshCachedTotals()
-            updateAllTimeStats()
+            viewModel.loadAll()
         }
     }
 
@@ -100,7 +77,7 @@ struct MenuBarView: View {
                         .font(.title2)
                         .foregroundStyle(.blue)
 
-                    Text(DistanceConverter.formatDistance(mouseDistance, unit: preferences.distanceUnit))
+                    Text(DistanceConverter.formatDistance(viewModel.mouseDistance, unit: preferences.distanceUnit))
                         .font(.title.bold())
 
                     Text("Distance")
@@ -118,7 +95,7 @@ struct MenuBarView: View {
                         .font(.title2)
                         .foregroundStyle(.green)
 
-                    Text("\(leftClicks + rightClicks + middleClicks)")
+                    Text("\(viewModel.totalClicks)")
                         .font(.title.bold())
 
                     Text("Clicks")
@@ -136,7 +113,7 @@ struct MenuBarView: View {
                         .font(.title2)
                         .foregroundStyle(.orange)
 
-                    let totalScroll = scrollVertical + scrollHorizontal
+                    let totalScroll = viewModel.scrollVertical + viewModel.scrollHorizontal
                     if totalScroll < 1000 {
                         Text(String(format: "%.0f px", totalScroll))
                             .font(.title.bold())
@@ -162,11 +139,11 @@ struct MenuBarView: View {
                     .font(.headline)
                     .padding(.horizontal)
 
-                if !chartData.isEmpty {
-                    Chart(chartData.suffix(7), id: \.date) { item in
+                if !viewModel.chartData.isEmpty {
+                    Chart(viewModel.chartData.suffix(7), id: \.date) { item in
                         BarMark(
-                            x: .value("Day", shortDay(from: item.date)),
-                            y: .value("Distance", chartDistance(item.mouseDistancePx))
+                            x: .value("Day", viewModel.shortDay(from: item.date)),
+                            y: .value("Distance", viewModel.chartDistance(item.mouseDistancePx, unit: preferences.distanceUnit))
                         )
                         .foregroundStyle(.blue.gradient)
                     }
@@ -183,8 +160,8 @@ struct MenuBarView: View {
             // Mouse Heatmap
             VStack(alignment: .leading, spacing: 8) {
                 DisclosureGroup("Mouse Heatmap") {
-                    if !heatmapData.isEmpty {
-                        HeatmapCanvas(data: heatmapData)
+                    if !viewModel.heatmapData.isEmpty {
+                        HeatmapCanvas(data: viewModel.heatmapData)
                             .frame(height: 200)
                             .padding(.top, 8)
                     } else {
@@ -206,7 +183,7 @@ struct MenuBarView: View {
                     .font(.title2)
                     .foregroundStyle(.purple)
 
-                Text("\(keystrokes)")
+                Text("\(viewModel.keystrokes)")
                     .font(.title.bold())
 
                 Text("Keystrokes Today")
@@ -225,10 +202,10 @@ struct MenuBarView: View {
                     .font(.headline)
                     .padding(.horizontal)
 
-                if !chartData.isEmpty {
-                    Chart(chartData.suffix(7), id: \.date) { item in
+                if !viewModel.chartData.isEmpty {
+                    Chart(viewModel.chartData.suffix(7), id: \.date) { item in
                         BarMark(
-                            x: .value("Day", shortDay(from: item.date)),
+                            x: .value("Day", viewModel.shortDay(from: item.date)),
                             y: .value("Keystrokes", item.keystrokes)
                         )
                         .foregroundStyle(.purple.gradient)
@@ -245,8 +222,8 @@ struct MenuBarView: View {
             // Keyboard Heatmap
             VStack(alignment: .leading, spacing: 8) {
                 DisclosureGroup("Keyboard Heatmap") {
-                    if !keyboardEntries.isEmpty {
-                        MiniKeyboardHeatmap(entries: keyboardEntries)
+                    if !viewModel.keyboardEntries.isEmpty {
+                        MiniKeyboardHeatmap(entries: viewModel.keyboardEntries)
                             .frame(height: 150)
                             .padding(.top, 8)
                     } else {
@@ -264,10 +241,9 @@ struct MenuBarView: View {
                     .font(.headline)
                     .padding(.horizontal)
 
-                if !keyboardEntries.isEmpty {
-                    let topKeys = keyboardEntries.sorted { $0.count > $1.count }.prefix(5)
+                if !viewModel.keyboardEntries.isEmpty {
                     HStack(spacing: 8) {
-                        ForEach(Array(topKeys), id: \.compositeId) { entry in
+                        ForEach(viewModel.topKeys, id: \.compositeId) { entry in
                             VStack(spacing: 4) {
                                 Text(KeyCodeMapping.keyName(for: entry.keyCode))
                                     .font(.caption.bold())
@@ -304,7 +280,7 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    Text(DistanceConverter.formatDistance(allTimeDistance, unit: preferences.distanceUnit))
+                    Text(DistanceConverter.formatDistance(viewModel.allTimeDistance, unit: preferences.distanceUnit))
                         .font(.title2.bold().monospacedDigit())
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -318,7 +294,7 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    Text("\(allTimeClicks)")
+                    Text("\(viewModel.allTimeClicks)")
                         .font(.title2.bold().monospacedDigit())
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -332,7 +308,7 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    Text("\(allTimeKeystrokes)")
+                    Text("\(viewModel.allTimeKeystrokes)")
                         .font(.title2.bold().monospacedDigit())
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -346,7 +322,7 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    let totalScroll = allTimeScrollVertical + allTimeScrollHorizontal
+                    let totalScroll = viewModel.allTimeScrollVertical + viewModel.allTimeScrollHorizontal
                     if totalScroll < 1000 {
                         Text(String(format: "%.0f px", totalScroll))
                             .font(.title2.bold().monospacedDigit())
@@ -362,91 +338,6 @@ struct MenuBarView: View {
             }
             .padding(.horizontal)
         }
-    }
-
-    private func updateStats() {
-        let mouseStats = MouseTracker.shared.getCurrentStats()
-        let keyboardStats = KeyboardTracker.shared.getCurrentKeystrokes()
-
-        let today = DateHelper.todayString()
-        if let summary = DatabaseManager.shared.getDailySummary(date: today) {
-            mouseDistance = summary.mouseDistancePx + mouseStats.distance
-            keystrokes = summary.keystrokes + keyboardStats
-            leftClicks = summary.mouseClicksLeft + mouseStats.left
-            rightClicks = summary.mouseClicksRight + mouseStats.right
-            middleClicks = summary.mouseClicksMiddle + mouseStats.middle
-            scrollVertical = summary.scrollDistanceVertical + mouseStats.scrollV
-            scrollHorizontal = summary.scrollDistanceHorizontal + mouseStats.scrollH
-        } else {
-            mouseDistance = mouseStats.distance
-            keystrokes = keyboardStats
-            leftClicks = mouseStats.left
-            rightClicks = mouseStats.right
-            middleClicks = mouseStats.middle
-            scrollVertical = mouseStats.scrollV
-            scrollHorizontal = mouseStats.scrollH
-        }
-    }
-
-    private func loadChartData() {
-        let calendar = Calendar.current
-        let today = Date()
-
-        guard let startDate = calendar.date(byAdding: .day, value: -6, to: today) else { return }
-
-        let startString = DateHelper.string(from: startDate)
-        let endString = DateHelper.string(from: today)
-
-        chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
-    }
-
-    private func loadHeatmapData() {
-        let today = DateHelper.todayString()
-        let entries = DatabaseManager.shared.getMouseHeatmap(date: today)
-        heatmapData = HeatmapGridBuilder.buildGrid(from: entries)
-    }
-
-    private func loadKeyboardData() {
-        let today = DateHelper.todayString()
-        keyboardEntries = DatabaseManager.shared.getKeyboardEntries(date: today)
-    }
-
-    private func refreshCachedTotals() {
-        cachedTotals = DatabaseManager.shared.getAllTimeTotals()
-        lastCacheTime = Date()
-    }
-
-    private func refreshAllTimeTotalsIfNeeded() {
-        guard Date().timeIntervalSince(lastCacheTime) >= cacheInterval else { return }
-        refreshCachedTotals()
-    }
-
-    private func updateAllTimeStats() {
-        let mouseStats = MouseTracker.shared.getCurrentStats()
-        allTimeDistance = cachedTotals.distance + mouseStats.distance
-        allTimeClicks = cachedTotals.totalClicks + mouseStats.left + mouseStats.right + mouseStats.middle
-        allTimeKeystrokes = cachedTotals.keystrokes + KeyboardTracker.shared.getCurrentKeystrokes()
-        allTimeScrollVertical = cachedTotals.scrollVertical + mouseStats.scrollV
-        allTimeScrollHorizontal = cachedTotals.scrollHorizontal + mouseStats.scrollH
-    }
-
-    private func chartDistance(_ pixels: Double) -> Double {
-        let meters = DistanceConverter.pixelsToMeters(pixels)
-        if preferences.distanceUnit == .metric {
-            return DistanceConverter.metersToKilometers(meters)
-        } else {
-            let feet = DistanceConverter.metersToFeet(meters)
-            return DistanceConverter.feetToMiles(feet)
-        }
-    }
-
-    private func shortDay(from dateString: String) -> String {
-        guard let date = DateHelper.date(from: dateString) else { return "" }
-
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "EEE"
-        return formatter.string(from: date)
     }
 }
 

--- a/InputMetrics/InputMetrics/Views/MouseStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/MouseStatsView.swift
@@ -1,37 +1,29 @@
 import SwiftUI
 import Charts
 
-enum TimeRange {
-    case week
-    case month
-    case year
-}
-
 struct MouseStatsView: View {
-    @State private var selectedRange: TimeRange = .week
-    @State private var chartData: [DailySummary] = []
-    @State private var allTimeStats: DailySummary?
+    @State private var viewModel = MouseStatsViewModel()
 
     var body: some View {
         VStack(spacing: 20) {
             // Time range selector
             HStack {
                 Spacer()
-                Picker("Range", selection: $selectedRange) {
+                Picker("Range", selection: $viewModel.selectedRange) {
                     Text("Week").tag(TimeRange.week)
                     Text("Month").tag(TimeRange.month)
                     Text("Year").tag(TimeRange.year)
                 }
                 .pickerStyle(.segmented)
                 .frame(width: 250)
-                .onChange(of: selectedRange) { _, _ in
-                    loadChartData()
+                .onChange(of: viewModel.selectedRange) { _, _ in
+                    viewModel.onRangeChanged()
                 }
             }
             .padding(.horizontal)
 
             // Chart
-            ChartView(data: chartData, range: selectedRange)
+            ChartView(data: viewModel.chartData, range: viewModel.selectedRange)
                 .frame(height: 250)
                 .padding()
 
@@ -50,18 +42,18 @@ struct MouseStatsView: View {
                     Text("All-Time Stats")
                         .font(.headline)
 
-                    if let stats = allTimeStats {
+                    if let stats = viewModel.allTimeStats {
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Distance: \(DistanceConverter.formatDistance(stats.mouseDistancePx))")
                             Text("Clicks: \(stats.mouseClicksLeft + stats.mouseClicksRight + stats.mouseClicksMiddle)")
-                            Text("Scroll: \(formatScrollDistance(vertical: stats.scrollDistanceVertical, horizontal: stats.scrollDistanceHorizontal))")
+                            Text("Scroll: \(viewModel.formatScrollDistance(vertical: stats.scrollDistanceVertical, horizontal: stats.scrollDistanceHorizontal))")
                             Text("Keystrokes: \(stats.keystrokes)")
 
                             Divider()
 
-                            Text("🌍 " + DistanceConverter.formatEarthComparison(stats.mouseDistancePx))
+                            Text("\u{1F30D} " + DistanceConverter.formatEarthComparison(stats.mouseDistancePx))
                                 .font(.caption)
-                            Text("🌙 " + DistanceConverter.formatMoonComparison(stats.mouseDistancePx))
+                            Text("\u{1F319} " + DistanceConverter.formatMoonComparison(stats.mouseDistancePx))
                                 .font(.caption)
                         }
                     } else {
@@ -75,52 +67,8 @@ struct MouseStatsView: View {
             .padding()
         }
         .onAppear {
-            loadChartData()
-            loadAllTimeStats()
+            viewModel.loadAll()
         }
-    }
-
-    private func loadChartData() {
-        let calendar = Calendar.current
-        let today = Date()
-
-        let daysBack: Int
-        switch selectedRange {
-        case .week: daysBack = 7
-        case .month: daysBack = 30
-        case .year: daysBack = 365
-        }
-
-        guard let startDate = calendar.date(byAdding: .day, value: -daysBack, to: today) else { return }
-
-        let startString = DateHelper.string(from: startDate)
-        let endString = DateHelper.string(from: today)
-
-        chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
-    }
-
-    private func formatScrollDistance(vertical: Double, horizontal: Double) -> String {
-        let total = vertical + horizontal
-        if total < 1000 {
-            return String(format: "%.0f px", total)
-        } else {
-            return String(format: "%.1f K px", total / 1000)
-        }
-    }
-
-    private func loadAllTimeStats() {
-        let totals = DatabaseManager.shared.getAllTimeTotals()
-
-        allTimeStats = DailySummary(
-            date: "",
-            mouseDistancePx: totals.distance,
-            mouseClicksLeft: totals.clicksLeft,
-            mouseClicksRight: totals.clicksRight,
-            mouseClicksMiddle: totals.clicksMiddle,
-            keystrokes: totals.keystrokes,
-            scrollDistanceVertical: totals.scrollVertical,
-            scrollDistanceHorizontal: totals.scrollHorizontal
-        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Create `@Observable` ViewModels for `MenuBarView`, `MouseStatsView`, and `KeyboardStatsView`
- Move all data loading, formatting, and state management into ViewModels (`MenuBarViewModel`, `MouseStatsViewModel`, `KeyboardStatsViewModel`)
- Views are now thin rendering layers that bind to ViewModel state via `@State`
- Extract shared `TimeRange` enum into its own model file

Closes #15

## Test plan
- Build the project and verify it compiles without errors
- Open the menu bar popover and verify mouse/keyboard stats update every second
- Switch between Mouse Metrics and Keyboard Metrics tabs
- Open the dashboard window and verify Mouse and Keyboard stats views load chart data
- Change the time range picker (Week/Month/Year) and verify charts reload
- Verify all-time stats display correctly in the menu bar view
- Verify heatmaps and top keys render as before

Generated with [Claude Code](https://claude.com/claude-code)