### PR TITLE
refactor: Extract shared utilities (DateHelper, HeatmapColor, HeatmapGridBuilder)

### DIFF
--- a/InputMetrics/InputMetrics/AppDelegate.swift
+++ b/InputMetrics/InputMetrics/AppDelegate.swift
@@ -126,10 +126,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let mouseStats = MouseTracker.shared.getCurrentStats()
         let keyboardStats = KeyboardTracker.shared.getCurrentKeystrokes()
 
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        let today = formatter.string(from: Date())
+        let today = DateHelper.todayString()
 
         Task.detached { [weak self] in
             let summary = DatabaseManager.shared.getDailySummary(date: today)

--- a/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
+++ b/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
@@ -39,7 +39,7 @@ class KeyboardTracker {
     }
 
     func persistData() {
-        let today = getTodayString()
+        let today = DateHelper.todayString()
         let currentHour = getCurrentHour()
 
         DatabaseManager.shared.updateDailySummary(
@@ -78,13 +78,6 @@ class KeyboardTracker {
 
     func getCurrentKeystrokes() -> Int {
         return totalKeystrokes
-    }
-
-    private func getTodayString() -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: Date())
     }
 
     private func getCurrentHour() -> Int {

--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -118,7 +118,7 @@ class MouseTracker {
 
         let bucket = bucketForPoint(point)
         let screenId = getScreenId(for: point)
-        let today = getTodayString()
+        let today = DateHelper.todayString()
 
         let key = HeatmapBucketKey(date: today, screenId: screenId, bucketX: bucket.x, bucketY: bucket.y)
         heatmapBuffer[key, default: 0] += 1
@@ -133,7 +133,7 @@ class MouseTracker {
     }
 
     func persistData() {
-        let today = getTodayString()
+        let today = DateHelper.todayString()
         let currentHour = getCurrentHour()
 
         DatabaseManager.shared.updateDailySummary(
@@ -208,13 +208,6 @@ class MouseTracker {
             }
         }
         return "primary"
-    }
-
-    private func getTodayString() -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: Date())
     }
 
     private func getCurrentHour() -> Int {

--- a/InputMetrics/InputMetrics/Utilities/DateHelper.swift
+++ b/InputMetrics/InputMetrics/Utilities/DateHelper.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum DateHelper {
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    static func todayString() -> String {
+        formatter.string(from: Date())
+    }
+
+    static func string(from date: Date) -> String {
+        formatter.string(from: date)
+    }
+
+    static func date(from string: String) -> Date? {
+        formatter.date(from: string)
+    }
+}

--- a/InputMetrics/InputMetrics/Utilities/HeatmapColor.swift
+++ b/InputMetrics/InputMetrics/Utilities/HeatmapColor.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+enum HeatmapColor {
+    static func forIntensity(_ intensity: Double) -> Color {
+        if intensity == 0 {
+            return Color.clear
+        } else if intensity < 0.2 {
+            return Color.blue.opacity(0.3)
+        } else if intensity < 0.4 {
+            return Color.cyan.opacity(0.5)
+        } else if intensity < 0.6 {
+            return Color.green.opacity(0.7)
+        } else if intensity < 0.8 {
+            return Color.yellow.opacity(0.8)
+        } else {
+            return Color.red.opacity(0.9)
+        }
+    }
+
+    static func forKeyboardIntensity(_ intensity: Double) -> Color {
+        if intensity == 0 {
+            return Color.gray.opacity(0.15)
+        } else if intensity < 0.2 {
+            return Color.purple.opacity(0.25)
+        } else if intensity < 0.4 {
+            return Color.purple.opacity(0.45)
+        } else if intensity < 0.6 {
+            return Color.purple.opacity(0.65)
+        } else if intensity < 0.8 {
+            return Color.purple.opacity(0.8)
+        } else {
+            return Color.purple
+        }
+    }
+}

--- a/InputMetrics/InputMetrics/Utilities/HeatmapGridBuilder.swift
+++ b/InputMetrics/InputMetrics/Utilities/HeatmapGridBuilder.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum HeatmapGridBuilder {
+    static func buildGrid(
+        from entries: [MouseHeatmapEntry],
+        gridSize: Int = Constants.heatmapGridSize
+    ) -> [[Int]] {
+        var grid = Array(repeating: Array(repeating: 0, count: gridSize), count: gridSize)
+
+        for entry in entries {
+            guard entry.bucketX >= 0,
+                  entry.bucketY >= 0,
+                  entry.bucketX < gridSize,
+                  entry.bucketY < gridSize
+            else { continue }
+            grid[entry.bucketY][entry.bucketX] += entry.clickCount
+        }
+
+        return grid
+    }
+}

--- a/InputMetrics/InputMetrics/Views/HeatmapCanvas.swift
+++ b/InputMetrics/InputMetrics/Views/HeatmapCanvas.swift
@@ -24,7 +24,7 @@ struct HeatmapCanvas: View {
                         height: cellHeight
                     )
 
-                    let color = colorForIntensity(intensity)
+                    let color = HeatmapColor.forIntensity(intensity)
                     context.fill(Path(rect), with: .color(color))
                 }
             }
@@ -35,19 +35,4 @@ struct HeatmapCanvas: View {
         .cornerRadius(8)
     }
 
-    private func colorForIntensity(_ intensity: Double) -> Color {
-        if intensity == 0 {
-            return Color.clear
-        } else if intensity < 0.2 {
-            return Color.blue.opacity(0.3)
-        } else if intensity < 0.4 {
-            return Color.cyan.opacity(0.5)
-        } else if intensity < 0.6 {
-            return Color.green.opacity(0.7)
-        } else if intensity < 0.8 {
-            return Color.yellow.opacity(0.8)
-        } else {
-            return Color.red.opacity(0.9)
-        }
-    }
 }

--- a/InputMetrics/InputMetrics/Views/HeatmapView.swift
+++ b/InputMetrics/InputMetrics/Views/HeatmapView.swift
@@ -43,7 +43,7 @@ struct HeatmapView: View {
                             height: cellHeight
                         )
 
-                        let color = colorForIntensity(intensity)
+                        let color = HeatmapColor.forIntensity(intensity)
                         context.fill(
                             Path(roundedRect: rect, cornerRadius: 0),
                             with: .color(color)
@@ -63,46 +63,14 @@ struct HeatmapView: View {
     }
 
     private func loadScreenIds() {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        let today = formatter.string(from: Date())
-
+        let today = DateHelper.todayString()
         screenIds = DatabaseManager.shared.getDistinctScreenIds(date: today)
     }
 
     private func loadHeatmapData() {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        let today = formatter.string(from: Date())
-
+        let today = DateHelper.todayString()
         let entries = DatabaseManager.shared.getMouseHeatmap(date: today, screenId: selectedScreenId)
-
-        var grid = Array(repeating: Array(repeating: 0, count: Constants.heatmapGridSize), count: Constants.heatmapGridSize)
-
-        for entry in entries {
-            guard entry.bucketX >= 0 && entry.bucketY >= 0 && entry.bucketX < Constants.heatmapGridSize && entry.bucketY < Constants.heatmapGridSize else { continue }
-            grid[entry.bucketY][entry.bucketX] += entry.clickCount
-        }
-
-        heatmapData = grid
-    }
-
-    private func colorForIntensity(_ intensity: Double) -> Color {
-        if intensity == 0 {
-            return Color.clear
-        } else if intensity < 0.2 {
-            return Color.blue.opacity(0.3)
-        } else if intensity < 0.4 {
-            return Color.cyan.opacity(0.5)
-        } else if intensity < 0.6 {
-            return Color.green.opacity(0.7)
-        } else if intensity < 0.8 {
-            return Color.yellow.opacity(0.8)
-        } else {
-            return Color.red.opacity(0.9)
-        }
+        heatmapData = HeatmapGridBuilder.buildGrid(from: entries)
     }
 }
 

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -320,7 +320,7 @@ struct MenuBarView: View {
         let mouseStats = MouseTracker.shared.getCurrentStats()
         let keyboardStats = KeyboardTracker.shared.getCurrentKeystrokes()
 
-        let today = getTodayString()
+        let today = DateHelper.todayString()
         if let summary = DatabaseManager.shared.getDailySummary(date: today) {
             mouseDistance = summary.mouseDistancePx + mouseStats.distance
             keystrokes = summary.keystrokes + keyboardStats
@@ -339,34 +339,23 @@ struct MenuBarView: View {
     private func loadChartData() {
         let calendar = Calendar.current
         let today = Date()
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
 
         guard let startDate = calendar.date(byAdding: .day, value: -6, to: today) else { return }
 
-        let startString = formatter.string(from: startDate)
-        let endString = formatter.string(from: today)
+        let startString = DateHelper.string(from: startDate)
+        let endString = DateHelper.string(from: today)
 
         chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
     }
 
     private func loadHeatmapData() {
-        let today = getTodayString()
+        let today = DateHelper.todayString()
         let entries = DatabaseManager.shared.getMouseHeatmap(date: today)
-
-        var grid = Array(repeating: Array(repeating: 0, count: 50), count: 50)
-
-        for entry in entries {
-            guard entry.bucketX >= 0 && entry.bucketY >= 0 && entry.bucketX < 50 && entry.bucketY < 50 else { continue }
-            grid[entry.bucketY][entry.bucketX] += entry.clickCount
-        }
-
-        heatmapData = grid
+        heatmapData = HeatmapGridBuilder.buildGrid(from: entries)
     }
 
     private func loadKeyboardData() {
-        let today = getTodayString()
+        let today = DateHelper.todayString()
         keyboardEntries = DatabaseManager.shared.getKeyboardEntries(date: today)
     }
 
@@ -398,20 +387,12 @@ struct MenuBarView: View {
     }
 
     private func shortDay(from dateString: String) -> String {
+        guard let date = DateHelper.date(from: dateString) else { return "" }
+
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        guard let date = formatter.date(from: dateString) else { return "" }
-
         formatter.dateFormat = "EEE"
         return formatter.string(from: date)
-    }
-
-    private func getTodayString() -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: Date())
     }
 }
 

--- a/InputMetrics/InputMetrics/Views/MiniKeyboardHeatmap.swift
+++ b/InputMetrics/InputMetrics/Views/MiniKeyboardHeatmap.swift
@@ -75,7 +75,7 @@ struct KeyCapView: View {
             }
         }
         .frame(width: 28 * width, height: 28)
-        .background(colorForIntensity(intensity))
+        .background(HeatmapColor.forKeyboardIntensity(intensity))
         .cornerRadius(4)
         .overlay(
             RoundedRectangle(cornerRadius: 4)
@@ -83,19 +83,4 @@ struct KeyCapView: View {
         )
     }
 
-    private func colorForIntensity(_ intensity: Double) -> Color {
-        if intensity == 0 {
-            return Color.gray.opacity(0.15)
-        } else if intensity < 0.2 {
-            return Color.purple.opacity(0.25)
-        } else if intensity < 0.4 {
-            return Color.purple.opacity(0.45)
-        } else if intensity < 0.6 {
-            return Color.purple.opacity(0.65)
-        } else if intensity < 0.8 {
-            return Color.purple.opacity(0.8)
-        } else {
-            return Color.purple
-        }
-    }
 }

--- a/InputMetrics/InputMetrics/Views/MouseStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/MouseStatsView.swift
@@ -82,9 +82,6 @@ struct MouseStatsView: View {
     private func loadChartData() {
         let calendar = Calendar.current
         let today = Date()
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
 
         let daysBack: Int
         switch selectedRange {
@@ -95,8 +92,8 @@ struct MouseStatsView: View {
 
         guard let startDate = calendar.date(byAdding: .day, value: -daysBack, to: today) else { return }
 
-        let startString = formatter.string(from: startDate)
-        let endString = formatter.string(from: today)
+        let startString = DateHelper.string(from: startDate)
+        let endString = DateHelper.string(from: today)
 
         chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
     }


### PR DESCRIPTION
## Summary
- Add `DateHelper` utility with a cached `DateFormatter`, replacing 6 duplicate `getTodayString()` implementations across MouseTracker, KeyboardTracker, MenuBarView, HeatmapView, MouseStatsView, and AppDelegate
- Add `HeatmapColor` utility with `forIntensity()` and `forKeyboardIntensity()`, replacing 3 duplicate `colorForIntensity()` methods in HeatmapCanvas, HeatmapView, and KeyCapView
- Add `HeatmapGridBuilder` utility to convert `[MouseHeatmapEntry]` to `[[Int]]` grid, replacing duplicate grid-building logic in MenuBarView and HeatmapView

Closes #40

## Test plan
- Build the project and verify no new compiler errors are introduced
- Open the menu bar popover and verify mouse/keyboard metrics display correctly
- Verify mouse heatmap renders with correct colors in both MenuBarView and MouseStatsView
- Verify keyboard heatmap renders with correct purple color scale
- Confirm date strings in stats match the expected yyyy-MM-dd format

🤖 Generated with [Claude Code](https://claude.com/claude-code)