### PR TITLE
fix(charts): Include live tracker data for current day

### DIFF
--- a/InputMetrics/InputMetrics/ViewModels/KeyboardStatsViewModel.swift
+++ b/InputMetrics/InputMetrics/ViewModels/KeyboardStatsViewModel.swift
@@ -42,6 +42,31 @@ final class KeyboardStatsViewModel {
         let endString = formatter.string(from: today)
 
         chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
+
+        let todayStr = formatter.string(from: today)
+        let mouseStats = MouseTracker.shared.getCurrentStats()
+        let keyboardStats = KeyboardTracker.shared.getCurrentKeystrokes()
+
+        if let idx = chartData.firstIndex(where: { $0.date == todayStr }) {
+            chartData[idx].mouseDistancePx += mouseStats.distance
+            chartData[idx].keystrokes += keyboardStats
+            chartData[idx].mouseClicksLeft += mouseStats.left
+            chartData[idx].mouseClicksRight += mouseStats.right
+            chartData[idx].mouseClicksMiddle += mouseStats.middle
+            chartData[idx].scrollDistanceVertical += mouseStats.scrollV
+            chartData[idx].scrollDistanceHorizontal += mouseStats.scrollH
+        } else {
+            chartData.append(DailySummary(
+                date: todayStr,
+                mouseDistancePx: mouseStats.distance,
+                mouseClicksLeft: mouseStats.left,
+                mouseClicksRight: mouseStats.right,
+                mouseClicksMiddle: mouseStats.middle,
+                keystrokes: keyboardStats,
+                scrollDistanceVertical: mouseStats.scrollV,
+                scrollDistanceHorizontal: mouseStats.scrollH
+            ))
+        }
     }
 
     func loadKeyboardData() {

--- a/InputMetrics/InputMetrics/ViewModels/MenuBarViewModel.swift
+++ b/InputMetrics/InputMetrics/ViewModels/MenuBarViewModel.swift
@@ -101,6 +101,31 @@ final class MenuBarViewModel {
         let endString = formatter.string(from: today)
 
         chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
+
+        let todayStr = formatter.string(from: today)
+        let mouseStats = MouseTracker.shared.getCurrentStats()
+        let keyboardStats = KeyboardTracker.shared.getCurrentKeystrokes()
+
+        if let idx = chartData.firstIndex(where: { $0.date == todayStr }) {
+            chartData[idx].mouseDistancePx += mouseStats.distance
+            chartData[idx].keystrokes += keyboardStats
+            chartData[idx].mouseClicksLeft += mouseStats.left
+            chartData[idx].mouseClicksRight += mouseStats.right
+            chartData[idx].mouseClicksMiddle += mouseStats.middle
+            chartData[idx].scrollDistanceVertical += mouseStats.scrollV
+            chartData[idx].scrollDistanceHorizontal += mouseStats.scrollH
+        } else {
+            chartData.append(DailySummary(
+                date: todayStr,
+                mouseDistancePx: mouseStats.distance,
+                mouseClicksLeft: mouseStats.left,
+                mouseClicksRight: mouseStats.right,
+                mouseClicksMiddle: mouseStats.middle,
+                keystrokes: keyboardStats,
+                scrollDistanceVertical: mouseStats.scrollV,
+                scrollDistanceHorizontal: mouseStats.scrollH
+            ))
+        }
     }
 
     func loadHeatmapData() {

--- a/InputMetrics/InputMetrics/ViewModels/MouseStatsViewModel.swift
+++ b/InputMetrics/InputMetrics/ViewModels/MouseStatsViewModel.swift
@@ -37,6 +37,31 @@ final class MouseStatsViewModel {
         let endString = formatter.string(from: today)
 
         chartData = DatabaseManager.shared.getDailySummaries(from: startString, to: endString)
+
+        let todayStr = formatter.string(from: today)
+        let mouseStats = MouseTracker.shared.getCurrentStats()
+        let keyboardStats = KeyboardTracker.shared.getCurrentKeystrokes()
+
+        if let idx = chartData.firstIndex(where: { $0.date == todayStr }) {
+            chartData[idx].mouseDistancePx += mouseStats.distance
+            chartData[idx].keystrokes += keyboardStats
+            chartData[idx].mouseClicksLeft += mouseStats.left
+            chartData[idx].mouseClicksRight += mouseStats.right
+            chartData[idx].mouseClicksMiddle += mouseStats.middle
+            chartData[idx].scrollDistanceVertical += mouseStats.scrollV
+            chartData[idx].scrollDistanceHorizontal += mouseStats.scrollH
+        } else {
+            chartData.append(DailySummary(
+                date: todayStr,
+                mouseDistancePx: mouseStats.distance,
+                mouseClicksLeft: mouseStats.left,
+                mouseClicksRight: mouseStats.right,
+                mouseClicksMiddle: mouseStats.middle,
+                keystrokes: keyboardStats,
+                scrollDistanceVertical: mouseStats.scrollV,
+                scrollDistanceHorizontal: mouseStats.scrollH
+            ))
+        }
     }
 
     func loadAllTimeStats() {


### PR DESCRIPTION
## Summary
Charts only queried the `daily_summary` database table, missing in-memory tracker data that hasn't been flushed yet (every 30s). This caused today's bar to be absent or show stale values.

## Changes
- Merge live `MouseTracker` and `KeyboardTracker` stats into today's chart entry in `KeyboardStatsViewModel.loadChartData()`
- Apply the same merge logic in `MouseStatsViewModel.loadChartData()`
- Apply the same merge logic in `MenuBarViewModel.loadChartData()`
- If today has no DB row yet, append a new `DailySummary` from live data alone

## Additional Notes
Mirrors the existing pattern in `MenuBarViewModel.updateStats()` which already merges DB + live data for the stat counters.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)