### PR TITLE
feat(Info.plist): Add missing App Store metadata keys

### DIFF
--- a/InputMetrics/InputMetrics/Info.plist
+++ b/InputMetrics/InputMetrics/Info.plist
@@ -23,7 +23,15 @@
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string></string>
+	<string>Copyright © 2025 Olivier Winkler. All rights reserved.</string>
+	<key>NSInputMonitoringUsageDescription</key>
+	<string>InputMetrics needs Input Monitoring access to track keyboard and mouse usage statistics.</string>
+	<key>NSAccessibilityUsageDescription</key>
+	<string>InputMetrics needs Accessibility access to monitor input events for usage statistics.</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>


### PR DESCRIPTION
## Summary
- Add `NSInputMonitoringUsageDescription` — required for input monitoring entitlement
- Add `NSAccessibilityUsageDescription` — required for accessibility entitlement
- Set `ITSAppUsesNonExemptEncryption` to `NO` — skips export compliance prompt
- Set `LSApplicationCategoryType` to `public.app-category.utilities`
- Fill `NSHumanReadableCopyright` with copyright string

Closes #92

## Test plan
- [ ] `xcodebuild -scheme InputMetrics -configuration Release build` passes
- [ ] Product > Archive > Validate App in Xcode passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)