### PR TITLE
fix(HourlySummary): Add CodingKeys for snake_case column mapping

### DIFF
--- a/InputMetrics/InputMetrics/Models/HourlySummary.swift
+++ b/InputMetrics/InputMetrics/Models/HourlySummary.swift
@@ -9,6 +9,14 @@ struct HourlySummary: Codable, FetchableRecord, PersistableRecord {
     var mouseClicks: Int
     var keystrokes: Int
 
+    enum CodingKeys: String, CodingKey {
+        case date
+        case hour
+        case mouseDistancePx = "mouse_distance_px"
+        case mouseClicks = "mouse_clicks"
+        case keystrokes
+    }
+
     enum Columns {
         static let date = Column(CodingKeys.date)
         static let hour = Column(CodingKeys.hour)


### PR DESCRIPTION
## Summary
- Add missing `CodingKeys` enum to `HourlySummary` to map camelCase Swift properties (`mouseDistancePx`, `mouseClicks`) to their snake_case SQLite column names (`mouse_distance_px`, `mouse_clicks`)
- Fixes TestFlight crash: `table hourly_summary has no column named mouseDistancePx`

## Test plan
- [ ] Build and run the app
- [ ] Verify hourly summary inserts succeed without SQLite errors
- [ ] Confirm existing data queries still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)