### PR TITLE
feat(DailySummary): Track daily first/last activity timestamps

### DIFF
--- a/InputMetrics/InputMetrics/Models/DailySummary.swift
+++ b/InputMetrics/InputMetrics/Models/DailySummary.swift
@@ -12,6 +12,8 @@ struct DailySummary: Codable, FetchableRecord, PersistableRecord {
     var keystrokes: Int
     var scrollDistanceVertical: Double
     var scrollDistanceHorizontal: Double
+    var firstActiveAt: String?
+    var lastActiveAt: String?
 
     enum CodingKeys: String, CodingKey {
         case date
@@ -22,6 +24,8 @@ struct DailySummary: Codable, FetchableRecord, PersistableRecord {
         case keystrokes
         case scrollDistanceVertical = "scroll_distance_vertical"
         case scrollDistanceHorizontal = "scroll_distance_horizontal"
+        case firstActiveAt = "first_active_at"
+        case lastActiveAt = "last_active_at"
     }
 
     enum Columns {
@@ -33,5 +37,7 @@ struct DailySummary: Codable, FetchableRecord, PersistableRecord {
         static let keystrokes = Column(CodingKeys.keystrokes)
         static let scrollDistanceVertical = Column(CodingKeys.scrollDistanceVertical)
         static let scrollDistanceHorizontal = Column(CodingKeys.scrollDistanceHorizontal)
+        static let firstActiveAt = Column(CodingKeys.firstActiveAt)
+        static let lastActiveAt = Column(CodingKeys.lastActiveAt)
     }
 }

--- a/InputMetrics/InputMetrics/Services/DatabaseManager.swift
+++ b/InputMetrics/InputMetrics/Services/DatabaseManager.swift
@@ -52,6 +52,7 @@ final class DatabaseManager: @unchecked Sendable {
         registerV3Migration(&migrator)
         registerV4Migration(&migrator)
         registerV5Migration(&migrator)
+        registerV6Migration(&migrator)
 
         return migrator
     }
@@ -118,6 +119,15 @@ final class DatabaseManager: @unchecked Sendable {
         }
     }
 
+    private func registerV6Migration(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("v6") { db in
+            try db.alter(table: "daily_summary") { t in
+                t.add(column: "first_active_at", .text)
+                t.add(column: "last_active_at", .text)
+            }
+        }
+    }
+
     // MARK: - Daily Summary Operations
 
     func updateDailySummary(
@@ -128,7 +138,9 @@ final class DatabaseManager: @unchecked Sendable {
         middleClicks: Int = 0,
         keystrokes: Int = 0,
         scrollVertical: Double = 0,
-        scrollHorizontal: Double = 0
+        scrollHorizontal: Double = 0,
+        firstActiveAt: String? = nil,
+        lastActiveAt: String? = nil
     ) {
         guard let db = dbQueue else { return }
 
@@ -137,8 +149,8 @@ final class DatabaseManager: @unchecked Sendable {
                 try db.write { db in
                     try db.execute(
                         sql: """
-                            INSERT INTO daily_summary (date, mouse_distance_px, mouse_clicks_left, mouse_clicks_right, mouse_clicks_middle, keystrokes, scroll_distance_vertical, scroll_distance_horizontal)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                            INSERT INTO daily_summary (date, mouse_distance_px, mouse_clicks_left, mouse_clicks_right, mouse_clicks_middle, keystrokes, scroll_distance_vertical, scroll_distance_horizontal, first_active_at, last_active_at)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                             ON CONFLICT(date) DO UPDATE SET
                                 mouse_distance_px = mouse_distance_px + excluded.mouse_distance_px,
                                 mouse_clicks_left = mouse_clicks_left + excluded.mouse_clicks_left,
@@ -146,9 +158,11 @@ final class DatabaseManager: @unchecked Sendable {
                                 mouse_clicks_middle = mouse_clicks_middle + excluded.mouse_clicks_middle,
                                 keystrokes = keystrokes + excluded.keystrokes,
                                 scroll_distance_vertical = scroll_distance_vertical + excluded.scroll_distance_vertical,
-                                scroll_distance_horizontal = scroll_distance_horizontal + excluded.scroll_distance_horizontal
+                                scroll_distance_horizontal = scroll_distance_horizontal + excluded.scroll_distance_horizontal,
+                                first_active_at = COALESCE(daily_summary.first_active_at, excluded.first_active_at),
+                                last_active_at = COALESCE(excluded.last_active_at, daily_summary.last_active_at)
                             """,
-                        arguments: [date, mouseDistance, leftClicks, rightClicks, middleClicks, keystrokes, scrollVertical, scrollHorizontal]
+                        arguments: [date, mouseDistance, leftClicks, rightClicks, middleClicks, keystrokes, scrollVertical, scrollHorizontal, firstActiveAt, lastActiveAt]
                     )
                 }
             } catch {

--- a/InputMetrics/InputMetrics/Services/EventMonitor.swift
+++ b/InputMetrics/InputMetrics/Services/EventMonitor.swift
@@ -10,6 +10,24 @@ class EventMonitor {
     private var retryCount = 0
     private let maxRetries = 30
 
+    private var firstActiveAt: String?
+    private var lastActiveAt: String?
+    private var currentDate: String?
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "HH:mm"
+        return f
+    }()
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
     private init() {}
 
     func start() {
@@ -100,6 +118,10 @@ class EventMonitor {
         }
     }
 
+    func getActivityTimes() -> (first: String?, last: String?) {
+        (firstActiveAt, lastActiveAt)
+    }
+
     nonisolated private func handleEvent(type: CGEventType, event: CGEvent) {
         let location = event.location
         let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
@@ -108,6 +130,19 @@ class EventMonitor {
         let scrollDeltaX = event.getDoubleValueField(.scrollWheelEventPointDeltaAxis2)
 
         MainActor.assumeIsolated {
+            let now = Date()
+            let today = Self.dateFormatter.string(from: now)
+            if currentDate != today {
+                firstActiveAt = nil
+                lastActiveAt = nil
+                currentDate = today
+            }
+            let timeString = Self.timeFormatter.string(from: now)
+            if firstActiveAt == nil {
+                firstActiveAt = timeString
+            }
+            lastActiveAt = timeString
+
             switch type {
             case .mouseMoved:
                 MouseTracker.shared.trackMovement(to: location)

--- a/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
+++ b/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
@@ -41,10 +41,13 @@ class KeyboardTracker {
     func persistData() {
         let today = DateHelper.todayString()
         let currentHour = getCurrentHour()
+        let activityTimes = EventMonitor.shared.getActivityTimes()
 
         DatabaseManager.shared.updateDailySummary(
             date: today,
-            keystrokes: totalKeystrokes
+            keystrokes: totalKeystrokes,
+            firstActiveAt: activityTimes.first,
+            lastActiveAt: activityTimes.last
         )
 
         DatabaseManager.shared.updateHourlySummary(

--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -142,6 +142,7 @@ class MouseTracker {
     func persistData() {
         let today = DateHelper.todayString()
         let currentHour = getCurrentHour()
+        let activityTimes = EventMonitor.shared.getActivityTimes()
 
         DatabaseManager.shared.updateDailySummary(
             date: today,
@@ -150,7 +151,9 @@ class MouseTracker {
             rightClicks: rightClicks,
             middleClicks: middleClicks,
             scrollVertical: scrollVertical,
-            scrollHorizontal: scrollHorizontal
+            scrollHorizontal: scrollHorizontal,
+            firstActiveAt: activityTimes.first,
+            lastActiveAt: activityTimes.last
         )
 
         DatabaseManager.shared.updateHourlySummary(

--- a/InputMetrics/InputMetrics/ViewModels/MenuBarViewModel.swift
+++ b/InputMetrics/InputMetrics/ViewModels/MenuBarViewModel.swift
@@ -24,6 +24,8 @@ final class MenuBarViewModel {
     var allTimeKeystrokes: Int = 0
     var allTimeScrollVertical: Double = 0
     var allTimeScrollHorizontal: Double = 0
+    var firstActiveAt: String?
+    var lastActiveAt: String?
     private var cachedTotals: DatabaseManager.AllTimeTotals = .zero
     private var lastCacheTime: Date = .distantPast
     private let cacheInterval: TimeInterval = 30
@@ -50,6 +52,8 @@ final class MenuBarViewModel {
         let keyboardStats = KeyboardTracker.shared.getCurrentKeystrokes()
         let today = todayString()
 
+        let liveActivity = EventMonitor.shared.getActivityTimes()
+
         if let summary = DatabaseManager.shared.getDailySummary(date: today) {
             mouseDistance = summary.mouseDistancePx + mouseStats.distance
             keystrokes = summary.keystrokes + keyboardStats
@@ -58,6 +62,8 @@ final class MenuBarViewModel {
             middleClicks = summary.mouseClicksMiddle + mouseStats.middle
             scrollVertical = summary.scrollDistanceVertical + mouseStats.scrollV
             scrollHorizontal = summary.scrollDistanceHorizontal + mouseStats.scrollH
+            firstActiveAt = summary.firstActiveAt ?? liveActivity.first
+            lastActiveAt = liveActivity.last ?? summary.lastActiveAt
         } else {
             mouseDistance = mouseStats.distance
             keystrokes = keyboardStats
@@ -66,6 +72,8 @@ final class MenuBarViewModel {
             middleClicks = mouseStats.middle
             scrollVertical = mouseStats.scrollV
             scrollHorizontal = mouseStats.scrollH
+            firstActiveAt = liveActivity.first
+            lastActiveAt = liveActivity.last
         }
     }
 
@@ -123,7 +131,9 @@ final class MenuBarViewModel {
                 mouseClicksMiddle: mouseStats.middle,
                 keystrokes: keyboardStats,
                 scrollDistanceVertical: mouseStats.scrollV,
-                scrollDistanceHorizontal: mouseStats.scrollH
+                scrollDistanceHorizontal: mouseStats.scrollH,
+                firstActiveAt: nil,
+                lastActiveAt: nil
             ))
         }
     }

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -43,6 +43,33 @@ struct MenuBarView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal)
 
+                    // Active Time Card
+                    HStack(spacing: 8) {
+                        Image(systemName: "clock")
+                            .font(.title3)
+                            .foregroundStyle(.teal)
+
+                        if let first = viewModel.firstActiveAt,
+                           let last = viewModel.lastActiveAt {
+                            Text("\(first) - \(last)")
+                                .font(.headline.monospacedDigit())
+                        } else {
+                            Text("No activity yet")
+                                .font(.headline)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+
+                        Text("Active Time")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding()
+                    .background(Color.secondary.opacity(0.1))
+                    .cornerRadius(12)
+                    .padding(.horizontal)
+
                     if viewModel.selectedTab == .mouse {
                         mouseMetricsView
                     } else {


### PR DESCRIPTION
## Summary
Track when the user starts and stops being active each day by recording first and last activity timestamps in the daily summary. This provides a quick glance at the daily activity window (e.g. "08:23 - 17:45") directly in the menu bar.

## Changes
- Add V6 database migration with `first_active_at` and `last_active_at` TEXT columns on `daily_summary`
- Add `firstActiveAt`/`lastActiveAt` optional properties to `DailySummary` model with CodingKeys and Columns
- Capture HH:mm timestamps in `EventMonitor.handleEvent()` on every input event, with midnight rollover reset
- Expose `getActivityTimes()` on `EventMonitor` for trackers and view model to read
- Pass activity timestamps through `MouseTracker.persistData()` and `KeyboardTracker.persistData()` to `DatabaseManager.updateDailySummary()`
- Use `COALESCE` in upsert SQL to preserve earliest `first_active_at` and latest `last_active_at`
- Add `firstActiveAt`/`lastActiveAt` to `MenuBarViewModel` with real-time blending of DB + live values
- Add Active Time card in `MenuBarView` shared across both metric tabs, showing clock icon and time range

## Additional Notes
Historical days without timestamps gracefully show "No activity yet" since the new columns are nullable.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)