### PR TITLE
fix(MenuBar): Add Dashboard button to popover

### DIFF
--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -32,6 +32,14 @@ struct MenuBarView: View {
                 .labelsHidden()
 
                 Spacer()
+
+                Button(action: {
+                    WindowManager.shared.openDashboardWindow()
+                }) {
+                    Image(systemName: "macwindow")
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dashboard")
             }
             .padding()
 


### PR DESCRIPTION
## Summary
- Add Dashboard button (macwindow icon) to MenuBar popover header for quick access to the full dashboard window

## Test plan
- [ ] Click the new dashboard button in the menu bar popover
- [ ] Verify it opens the dashboard window via WindowManager

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)