### PR TITLE
fix: Background event monitoring suspended by App Nap

### DIFF
--- a/InputMetrics/InputMetrics/AppDelegate.swift
+++ b/InputMetrics/InputMetrics/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Prevent App Nap from suspending background event monitoring
         backgroundActivity = ProcessInfo.processInfo.beginActivity(
-            options: [.userInitiated, .idleSystemSleepDisabled],
+            options: .userInitiated,
             reason: "Continuous input event monitoring"
         )
 
@@ -139,6 +139,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        if let activity = backgroundActivity {
+            ProcessInfo.processInfo.endActivity(activity)
+            backgroundActivity = nil
+        }
+
         liveStatsTimer?.invalidate()
         liveStatsTimer = nil
         HotkeyManager.shared.stop()
@@ -155,19 +160,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Live Stats
 
     private func startLiveStatsTimer() {
-        liveStatsTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+        let statsTimer = Timer(timeInterval: 2.0, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 self?.updateLiveStats()
             }
         }
+        RunLoop.current.add(statsTimer, forMode: .common)
+        liveStatsTimer = statsTimer
     }
 
     private func startMilestoneCheckTimer() {
-        milestoneTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
+        let timer = Timer(timeInterval: 300, repeats: true) { _ in
             Task { @MainActor in
                 NotificationManager.shared.checkMilestones()
             }
         }
+        RunLoop.current.add(timer, forMode: .common)
+        milestoneTimer = timer
     }
 
     private func updateLiveStats() {

--- a/InputMetrics/InputMetrics/Services/EventMonitor.swift
+++ b/InputMetrics/InputMetrics/Services/EventMonitor.swift
@@ -105,18 +105,20 @@ class EventMonitor {
 
         self.eventTap = tap
         let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+        CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
         AppLogger.events.info("Event monitoring started")
         return true
     }
 
     func startAppTracking() {
-        appPersistTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: 60, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 self?.persistAppUsage()
             }
         }
+        RunLoop.current.add(timer, forMode: .common)
+        appPersistTimer = timer
     }
 
     private func persistAppUsage() {
@@ -135,7 +137,7 @@ class EventMonitor {
 
     private func startRetryTimer() {
         retryCount = 0
-        retryTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] timer in
+        let timer = Timer(timeInterval: 2.0, repeats: true) { [weak self] timer in
             guard let self else { timer.invalidate(); return }
             MainActor.assumeIsolated {
                 self.retryCount += 1
@@ -150,6 +152,8 @@ class EventMonitor {
                 }
             }
         }
+        RunLoop.current.add(timer, forMode: .common)
+        retryTimer = timer
     }
 
     func getActivityTimes() -> (first: String?, last: String?) {

--- a/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
+++ b/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
@@ -62,11 +62,13 @@ class KeyboardTracker {
     }
 
     private func setupPersistTimer() {
-        persistTimer = Timer.scheduledTimer(withTimeInterval: persistInterval, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: persistInterval, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 self?.persistData()
             }
         }
+        RunLoop.current.add(timer, forMode: .common)
+        persistTimer = timer
     }
 
     func persistData() {

--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -153,11 +153,13 @@ class MouseTracker {
     }
 
     private func setupPersistTimer() {
-        persistTimer = Timer.scheduledTimer(withTimeInterval: persistInterval, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: persistInterval, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 self?.persistData()
             }
         }
+        RunLoop.current.add(timer, forMode: .common)
+        persistTimer = timer
     }
 
     func persistData() {


### PR DESCRIPTION
## Summary
The app only records input events when the menu bar popover is open. macOS App Nap suspends the RunLoop, timers, and CGEvent tap delivery when the accessory-mode app has no visible windows. This fixes the core tracking functionality to work continuously in the background.

## Changes
- Add `ProcessInfo.beginActivity(options: .userInitiated)` in AppDelegate to prevent App Nap from suspending the process
- End the background activity assertion in `applicationWillTerminate` for proper cleanup
- Change all `Timer.scheduledTimer()` calls to `Timer()` + `RunLoop.current.add(forMode: .common)` across MouseTracker, KeyboardTracker, EventMonitor, and AppDelegate to ensure timers fire during modal/tracking RunLoop modes
- Use `CFRunLoopGetMain()` instead of `CFRunLoopGetCurrent()` for the CGEvent tap source for explicit main RunLoop targeting

## Additional Notes
- `.idleSystemSleepDisabled` was intentionally omitted — only `.userInitiated` is needed to prevent App Nap without blocking system sleep (battery impact)
- The retry timer in EventMonitor was also converted for consistency

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)