### PR TITLE
fix: Prevent CMD+Q from accidentally quitting the menu bar app

### DIFF
--- a/InputMetrics/InputMetrics/AppDelegate.swift
+++ b/InputMetrics/InputMetrics/AppDelegate.swift
@@ -10,6 +10,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var milestoneTimer: Timer?
     private var backgroundActivity: NSObjectProtocol?
     private var keyboardPermissionTimer: Timer?
+    private var isQuittingFromMenu = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Prevent App Nap from suspending background event monitoring
@@ -138,7 +139,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func quitApp() {
+        isQuittingFromMenu = true
         NSApp.terminate(nil)
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if isQuittingFromMenu {
+            return .terminateNow
+        }
+
+        let alert = NSAlert()
+        alert.messageText = "Quit InputMetrics?"
+        alert.informativeText = "InputMetrics runs in the menu bar to track your input. To quit, use the menu bar icon's right-click menu."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Keep Running")
+        alert.addButton(withTitle: "Quit")
+
+        let response = alert.runModal()
+        if response == .alertSecondButtonReturn {
+            return .terminateNow
+        }
+        return .terminateCancel
     }
 
     func applicationWillTerminate(_ notification: Notification) {


### PR DESCRIPTION
## Summary
- Add `applicationShouldTerminate(_:)` with confirmation alert when CMD+Q is pressed
- Alert shows "Keep Running" (default) and "Quit" options with explanation about menu bar usage
- Right-click menu bar → "Quit InputMetrics" bypasses the alert via `isQuittingFromMenu` flag

Closes #156

## Test plan
- [ ] Open Settings window → press CMD+Q → alert appears with "Keep Running" / "Quit"
- [ ] Click "Keep Running" → app stays running, window stays open
- [ ] Click "Quit" → app terminates
- [ ] Right-click menu bar icon → "Quit InputMetrics" → quits immediately without alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)