### PR TITLE
fix(ci): Override signing to Developer ID Application in release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,10 @@ jobs:
             -scheme InputMetrics \
             -configuration Release \
             -destination 'platform=macOS' \
-            -archivePath build/InputMetrics.xcarchive
+            -archivePath build/InputMetrics.xcarchive \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Developer ID Application" \
+            DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }}
 
       - name: Export app
         run: |


### PR DESCRIPTION
Automatic signing looks for Mac Development cert which isn't available in CI. Use manual signing with Developer ID Application identity.