### PR TITLE
fix(db): Use CASE WHEN for peak stats in upsert

### DIFF
--- a/InputMetrics/InputMetrics/Services/DatabaseManager.swift
+++ b/InputMetrics/InputMetrics/Services/DatabaseManager.swift
@@ -203,8 +203,8 @@ final class DatabaseManager: @unchecked Sendable {
                                 last_active_at = COALESCE(excluded.last_active_at, daily_summary.last_active_at),
                                 active_minutes = active_minutes + excluded.active_minutes,
                                 avg_mouse_speed = CASE WHEN excluded.avg_mouse_speed > 0 THEN excluded.avg_mouse_speed ELSE daily_summary.avg_mouse_speed END,
-                                peak_mouse_speed = MAX(daily_summary.peak_mouse_speed, excluded.peak_mouse_speed),
-                                peak_wpm = MAX(daily_summary.peak_wpm, excluded.peak_wpm)
+                                peak_mouse_speed = CASE WHEN excluded.peak_mouse_speed > daily_summary.peak_mouse_speed THEN excluded.peak_mouse_speed ELSE daily_summary.peak_mouse_speed END,
+                                peak_wpm = CASE WHEN excluded.peak_wpm > daily_summary.peak_wpm THEN excluded.peak_wpm ELSE daily_summary.peak_wpm END
                             """,
                         arguments: [date, mouseDistance, leftClicks, rightClicks, middleClicks, keystrokes, scrollVertical, scrollHorizontal, firstActiveAt, lastActiveAt, activeMinutes, avgMouseSpeed, peakMouseSpeed, peakWPM]
                     )


### PR DESCRIPTION
## Summary
- Replaces `MAX()` with explicit `CASE WHEN` for `peak_mouse_speed` and `peak_wpm` in the ON CONFLICT upsert
- `MAX()` as an aggregate function may not behave correctly in SQLite UPDATE context

Closes #168

## Test plan
- [ ] Verify peak_mouse_speed retains the higher value across upserts
- [ ] Verify peak_wpm retains the higher value across upserts

🤖 Generated with [Claude Code](https://claude.com/claude-code)