### PR TITLE
chore: Add PrivacyInfo.xcprivacy manifest

### DIFF
--- a/InputMetrics/InputMetrics/PrivacyInfo.xcprivacy
+++ b/InputMetrics/InputMetrics/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds Apple Privacy Manifest (`PrivacyInfo.xcprivacy`) required for app distribution
- Declares no tracking, no collected data types, and UserDefaults API usage (reason CA92.1)

Closes #167

## Test plan
- [ ] Verify the manifest is included in the built app bundle
- [ ] Verify no App Store / notarization warnings related to privacy manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)