### PR TITLE
docs: Fix inaccurate sandboxing claim on website

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -332,7 +332,7 @@
         <li><strong>Accessibility:</strong> Allows the app to monitor global input events (keyboard and mouse)</li>
         <li><strong>Input Monitoring:</strong> Required by macOS for apps that observe key and pointer events</li>
       </ul>
-      <p>The app runs sandboxed with no other entitlements. If permissions are not granted, InputMetrics will prompt you and open the relevant System Settings pane.</p>
+      <p>The app runs outside the sandbox to enable input event monitoring via CGEventTap. It has no network entitlements and makes zero network requests. If permissions are not granted, InputMetrics will prompt you and open the relevant System Settings pane.</p>
     </section>
 
     <!-- Privacy Policy -->
@@ -369,7 +369,7 @@
       <ul>
         <li>All data is stored exclusively on your device</li>
         <li>The app makes zero network requests &mdash; no analytics, no telemetry, no crash reporting, no update checks</li>
-        <li>The app is sandboxed and has no network entitlements</li>
+        <li>The app runs outside the sandbox (required for CGEventTap) and has no network entitlements</li>
         <li>There is no server, no cloud sync, and no third-party service integration</li>
       </ul>
 


### PR DESCRIPTION
## Summary
- Fixes two inaccurate claims in `docs/index.html` that the app runs sandboxed
- The app has `com.apple.security.app-sandbox: false` (required for CGEventTap)
- Updated Permissions section and Privacy Policy section to reflect this accurately

Closes #183

## Test plan
- [ ] Review updated text in both sections for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)