### PR TITLE
fix(tracker): Remove NotificationCenter observer in MouseTracker cleanup

### DIFF
--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -45,13 +45,14 @@ class MouseTracker {
     }
 
     private var screenCache: ScreenCache?
+    private var screenObserver: NSObjectProtocol?
 
     private init() {
         setupPersistTimer()
         rebuildScreenCache()
         DistanceConverter.refreshDPI()
 
-        NotificationCenter.default.addObserver(
+        screenObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didChangeScreenParametersNotification,
             object: nil,
             queue: .main
@@ -268,6 +269,9 @@ class MouseTracker {
     nonisolated deinit {
         MainActor.assumeIsolated {
             persistTimer?.invalidate()
+            if let observer = screenObserver {
+                NotificationCenter.default.removeObserver(observer)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Stores the observer token from `addObserver(forName:)` in a property
- Removes the observer in `deinit` to prevent potential leaks

Closes #169

## Test plan
- [ ] Verify MouseTracker cleanup removes the screen parameter change observer

🤖 Generated with [Claude Code](https://claude.com/claude-code)