### PR TITLE
fix(notifications): Check system permission before sending

### DIFF
--- a/InputMetrics/InputMetrics/AppDelegate.swift
+++ b/InputMetrics/InputMetrics/AppDelegate.swift
@@ -80,7 +80,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Setup notifications if enabled
         if UserPreferences.shared.notificationsEnabled {
             NotificationManager.shared.requestPermission()
-            NotificationManager.shared.scheduleDailySummary()
+            Task {
+                await NotificationManager.shared.scheduleDailySummary()
+            }
         }
 
         // Start milestone check timer
@@ -229,7 +231,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func startMilestoneCheckTimer() {
         let timer = Timer(timeInterval: 300, repeats: true) { _ in
             Task { @MainActor in
-                NotificationManager.shared.checkMilestones()
+                await NotificationManager.shared.checkMilestones()
             }
         }
         RunLoop.current.add(timer, forMode: .common)

--- a/InputMetrics/InputMetrics/Services/NotificationManager.swift
+++ b/InputMetrics/InputMetrics/Services/NotificationManager.swift
@@ -15,8 +15,14 @@ class NotificationManager {
         }
     }
 
-    func sendDailySummaryNotification(keystrokes: Int, distance: String, clicks: Int) {
+    private func isAuthorized() async -> Bool {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        return settings.authorizationStatus == .authorized
+    }
+
+    func sendDailySummaryNotification(keystrokes: Int, distance: String, clicks: Int) async {
         guard UserPreferences.shared.notificationsEnabled else { return }
+        guard await isAuthorized() else { return }
 
         let content = UNMutableNotificationContent()
         content.title = "Daily Summary"
@@ -24,11 +30,12 @@ class NotificationManager {
         content.sound = .default
 
         let request = UNNotificationRequest(identifier: "daily-summary-\(DateHelper.todayString())", content: content, trigger: nil)
-        UNUserNotificationCenter.current().add(request)
+        try? await UNUserNotificationCenter.current().add(request)
     }
 
-    func sendMilestoneNotification(title: String, body: String) {
+    func sendMilestoneNotification(title: String, body: String) async {
         guard UserPreferences.shared.notificationsEnabled else { return }
+        guard await isAuthorized() else { return }
 
         let content = UNMutableNotificationContent()
         content.title = title
@@ -36,11 +43,12 @@ class NotificationManager {
         content.sound = .default
 
         let request = UNNotificationRequest(identifier: "milestone-\(UUID().uuidString)", content: content, trigger: nil)
-        UNUserNotificationCenter.current().add(request)
+        try? await UNUserNotificationCenter.current().add(request)
     }
 
-    func scheduleDailySummary() {
+    func scheduleDailySummary() async {
         guard UserPreferences.shared.notificationsEnabled else { return }
+        guard await isAuthorized() else { return }
 
         // Schedule for end of day (6 PM)
         var dateComponents = DateComponents()
@@ -55,11 +63,12 @@ class NotificationManager {
         content.sound = .default
 
         let request = UNNotificationRequest(identifier: "daily-summary-reminder", content: content, trigger: trigger)
-        UNUserNotificationCenter.current().add(request)
+        try? await UNUserNotificationCenter.current().add(request)
     }
 
-    func checkMilestones() {
+    func checkMilestones() async {
         guard UserPreferences.shared.notificationsEnabled else { return }
+        guard await isAuthorized() else { return }
 
         let totals = DatabaseManager.shared.getAllTimeTotals()
         let totalClicks = totals.totalClicks
@@ -72,12 +81,12 @@ class NotificationManager {
         let lastKeystrokeMilestone = UserDefaults.standard.integer(forKey: "lastKeystrokeMilestone")
 
         if let milestone = clickMilestones.first(where: { $0 > lastClickMilestone && totalClicks >= $0 }) {
-            sendMilestoneNotification(title: "Click Milestone!", body: "You've reached \(milestone) total clicks!")
+            await sendMilestoneNotification(title: "Click Milestone!", body: "You've reached \(milestone) total clicks!")
             UserDefaults.standard.set(milestone, forKey: "lastClickMilestone")
         }
 
         if let milestone = keystrokeMilestones.first(where: { $0 > lastKeystrokeMilestone && totalKeystrokes >= $0 }) {
-            sendMilestoneNotification(title: "Keystroke Milestone!", body: "You've reached \(milestone) total keystrokes!")
+            await sendMilestoneNotification(title: "Keystroke Milestone!", body: "You've reached \(milestone) total keystrokes!")
             UserDefaults.standard.set(milestone, forKey: "lastKeystrokeMilestone")
         }
     }

--- a/InputMetrics/InputMetrics/Views/SettingsView.swift
+++ b/InputMetrics/InputMetrics/Views/SettingsView.swift
@@ -208,7 +208,9 @@ struct SettingsView: View {
                                         .onChange(of: preferences.notificationsEnabled) { _, enabled in
                                             if enabled {
                                                 NotificationManager.shared.requestPermission()
-                                                NotificationManager.shared.scheduleDailySummary()
+                                                Task {
+                                                    await NotificationManager.shared.scheduleDailySummary()
+                                                }
                                             }
                                         }
                                 }


### PR DESCRIPTION
## Summary
- Adds `isAuthorized()` async method that checks `UNUserNotificationCenter` authorization status
- All notification send/schedule methods now verify system permission before proceeding
- Updated callers in AppDelegate and SettingsView to use async API

Closes #170

## Test plan
- [ ] Verify notifications are not sent when system permission is revoked
- [ ] Verify notifications still work when permission is granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)