### PR TITLE
fix(notifications): Replace print() with AppLogger

### DIFF
--- a/InputMetrics/InputMetrics/Services/NotificationManager.swift
+++ b/InputMetrics/InputMetrics/Services/NotificationManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import UserNotifications
 
 @MainActor
@@ -10,7 +11,7 @@ class NotificationManager {
     func requestPermission() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error {
-                print("Notification permission error: \(error)")
+                AppLogger.general.error("Notification permission error: \(error)")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replaces `print("Notification permission error:")` with `AppLogger.general.error()`
- Adds `import os` for Logger support

Closes #172

## Test plan
- [ ] Verify notification errors are logged via os.Logger instead of stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)