### PR TITLE
feat(a11y): Add accessibility labels to interactive elements and metrics

### DIFF
--- a/InputMetrics/InputMetrics/Views/AppUsageView.swift
+++ b/InputMetrics/InputMetrics/Views/AppUsageView.swift
@@ -21,6 +21,8 @@ struct AppUsageView: View {
                     )
                     .foregroundStyle(.blue)
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("App usage chart showing activity for top \(topApps.count) apps")
                 .frame(height: CGFloat(topApps.count * 28))
             }
         }

--- a/InputMetrics/InputMetrics/Views/ChartView.swift
+++ b/InputMetrics/InputMetrics/Views/ChartView.swift
@@ -63,6 +63,8 @@ struct ChartView: View {
                             }
                     }
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("\(chartTitle) chart for \(range == .week ? "this week" : range == .month ? "this month" : "this year")")
                 .chartYAxisLabel(yAxisLabel)
                 .chartOverlay { proxy in
                     GeometryReader { geometry in

--- a/InputMetrics/InputMetrics/Views/HourlyBreakdownView.swift
+++ b/InputMetrics/InputMetrics/Views/HourlyBreakdownView.swift
@@ -40,6 +40,8 @@ struct HourlyBreakdownView: View {
                         }
                     }
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Hourly breakdown chart showing keystrokes and clicks by hour")
                 .frame(height: 120)
             }
         }

--- a/InputMetrics/InputMetrics/Views/KeyboardStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/KeyboardStatsView.swift
@@ -12,6 +12,7 @@ struct KeyboardStatsView: View {
                     Image(systemName: "chevron.left")
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Previous day")
 
                 DatePicker("", selection: $viewModel.selectedDate, displayedComponents: .date)
                     .labelsHidden()
@@ -23,6 +24,7 @@ struct KeyboardStatsView: View {
                     Image(systemName: "chevron.right")
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Next day")
                 .disabled(Calendar.current.isDateInToday(viewModel.selectedDate))
 
                 if !Calendar.current.isDateInToday(viewModel.selectedDate) {
@@ -59,6 +61,8 @@ struct KeyboardStatsView: View {
 
             // Keyboard heatmap
             KeyboardHeatmapView(entries: viewModel.keyboardEntries)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Keyboard heatmap showing key usage frequency")
                 .padding()
 
             // Top keys

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -138,6 +138,8 @@ struct MenuBarView: View {
                                         .foregroundStyle(.purple)
                                     ProgressView(value: viewModel.keystrokeProgress)
                                         .tint(.purple)
+                                        .accessibilityLabel("Keystroke goal progress")
+                                        .accessibilityValue("\(Int(viewModel.keystrokeProgress * 100)) percent")
                                     Text("\(Int(viewModel.keystrokeProgress * 100))%")
                                         .font(.caption)
                                         .monospacedDigit()
@@ -149,6 +151,8 @@ struct MenuBarView: View {
                                         .foregroundStyle(.blue)
                                     ProgressView(value: viewModel.distanceProgress)
                                         .tint(.blue)
+                                        .accessibilityLabel("Distance goal progress")
+                                        .accessibilityValue("\(Int(viewModel.distanceProgress * 100)) percent")
                                     Text("\(Int(viewModel.distanceProgress * 100))%")
                                         .font(.caption)
                                         .monospacedDigit()
@@ -213,6 +217,8 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Distance: \(DistanceConverter.formatDistance(viewModel.mouseDistance, unit: preferences.distanceUnit))")
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                 .padding()
                 .background(Color.secondary.opacity(0.1))
@@ -231,6 +237,8 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Clicks: \(viewModel.totalClicks)")
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                 .padding()
                 .background(Color.secondary.opacity(0.1))
@@ -255,6 +263,8 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Scroll: \(String(format: "%.0f pixels", viewModel.scrollVertical + viewModel.scrollHorizontal))")
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                 .padding()
                 .background(Color.secondary.opacity(0.1))
@@ -275,6 +285,8 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Active time: \(viewModel.activeMinutes / 60) hours \(viewModel.activeMinutes % 60) minutes")
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                 .padding()
                 .background(Color.secondary.opacity(0.1))
@@ -349,6 +361,8 @@ struct MenuBarView: View {
                                 }
                         }
                     }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("Weekly mouse distance chart")
                     .padding(.horizontal)
                 } else {
                     Text("No data yet")
@@ -362,6 +376,8 @@ struct MenuBarView: View {
                 DisclosureGroup("Mouse Heatmap") {
                     if !viewModel.heatmapData.isEmpty {
                         HeatmapCanvas(data: viewModel.heatmapData)
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityLabel("Mouse click heatmap showing click distribution")
                             .frame(height: 200)
                             .padding(.top, 8)
                     } else {
@@ -390,6 +406,8 @@ struct MenuBarView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Keystrokes today: \(viewModel.keystrokes)")
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
             .background(Color.secondary.opacity(0.1))
@@ -410,6 +428,8 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Peak typing speed: \(String(format: "%.0f", viewModel.peakWPM)) words per minute")
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()
                 .background(Color.secondary.opacity(0.1))
@@ -482,6 +502,8 @@ struct MenuBarView: View {
                                 }
                         }
                     }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("Weekly keystrokes chart")
                     .padding(.horizontal)
                 } else {
                     Text("No data yet")
@@ -495,6 +517,8 @@ struct MenuBarView: View {
                 DisclosureGroup("Keyboard Heatmap") {
                     if !viewModel.keyboardEntries.isEmpty {
                         MiniKeyboardHeatmap(entries: viewModel.keyboardEntries)
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityLabel("Keyboard heatmap showing key usage frequency")
                             .frame(height: 150)
                             .padding(.top, 8)
                     } else {
@@ -573,6 +597,8 @@ struct MenuBarView: View {
                     Text(DistanceConverter.formatDistance(viewModel.allTimeDistance, unit: preferences.distanceUnit))
                         .font(.title2.bold().monospacedDigit())
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("All-time distance: \(DistanceConverter.formatDistance(viewModel.allTimeDistance, unit: preferences.distanceUnit))")
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()
                 .background(Color.blue.opacity(0.1))
@@ -587,6 +613,8 @@ struct MenuBarView: View {
                     Text("\(viewModel.allTimeClicks)")
                         .font(.title2.bold().monospacedDigit())
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("All-time clicks: \(viewModel.allTimeClicks)")
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()
                 .background(Color.green.opacity(0.1))
@@ -601,6 +629,8 @@ struct MenuBarView: View {
                     Text("\(viewModel.allTimeKeystrokes)")
                         .font(.title2.bold().monospacedDigit())
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("All-time keystrokes: \(viewModel.allTimeKeystrokes)")
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()
                 .background(Color.purple.opacity(0.1))
@@ -621,6 +651,8 @@ struct MenuBarView: View {
                             .font(.title2.bold().monospacedDigit())
                     }
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("All-time scroll: \(String(format: "%.0f pixels", viewModel.allTimeScrollVertical + viewModel.allTimeScrollHorizontal))")
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()
                 .background(Color.orange.opacity(0.1))

--- a/InputMetrics/InputMetrics/Views/MouseStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/MouseStatsView.swift
@@ -12,6 +12,7 @@ struct MouseStatsView: View {
                     Image(systemName: "chevron.left")
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Previous day")
 
                 DatePicker("", selection: $viewModel.selectedDate, displayedComponents: .date)
                     .labelsHidden()
@@ -23,6 +24,7 @@ struct MouseStatsView: View {
                     Image(systemName: "chevron.right")
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Next day")
                 .disabled(Calendar.current.isDateInToday(viewModel.selectedDate))
 
                 if !Calendar.current.isDateInToday(viewModel.selectedDate) {

--- a/InputMetrics/InputMetrics/Views/OnboardingView.swift
+++ b/InputMetrics/InputMetrics/Views/OnboardingView.swift
@@ -52,6 +52,8 @@ struct OnboardingView: View {
                         .frame(width: 8, height: 8)
                 }
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Step \(currentStep + 1) of \(steps.count)")
 
             // Navigation
             HStack {


### PR DESCRIPTION
## Summary
Adds accessibility labels across 7 view files:
- **Navigation buttons**: chevron left/right get "Previous/Next day" labels
- **Metric cards**: combined labels (name + value) for VoiceOver
- **Progress bars**: accessibilityLabel + accessibilityValue for goals
- **Charts**: descriptive labels for chart containers
- **Heatmaps**: summary labels for mouse and keyboard heatmaps
- **Onboarding**: step progress dots labeled "Step X of Y"

Closes #175

## Test plan
- [ ] Test with VoiceOver enabled — verify all interactive elements are announced
- [ ] Verify navigation buttons read "Previous day" / "Next day"

🤖 Generated with [Claude Code](https://claude.com/claude-code)