### PR TITLE
feat(ui): Add loading states to stats views

### DIFF
--- a/InputMetrics/InputMetrics/ViewModels/KeyboardStatsViewModel.swift
+++ b/InputMetrics/InputMetrics/ViewModels/KeyboardStatsViewModel.swift
@@ -8,6 +8,7 @@ final class KeyboardStatsViewModel {
     var selectedDate: Date = Date()
     var chartData: [DailySummary] = []
     var keyboardEntries: [KeyboardEntry] = []
+    var isLoading = true
 
     var topKeys: [(id: String, name: String, count: Int)] {
         let sorted = keyboardEntries.sorted { $0.count > $1.count }
@@ -15,8 +16,10 @@ final class KeyboardStatsViewModel {
     }
 
     func loadAll() {
+        isLoading = true
         loadChartData()
         loadKeyboardData()
+        isLoading = false
     }
 
     func onRangeChanged() {

--- a/InputMetrics/InputMetrics/ViewModels/MouseStatsViewModel.swift
+++ b/InputMetrics/InputMetrics/ViewModels/MouseStatsViewModel.swift
@@ -8,10 +8,13 @@ final class MouseStatsViewModel {
     var selectedDate: Date = Date()
     var chartData: [DailySummary] = []
     var allTimeStats: DailySummary?
+    var isLoading = true
 
     func loadAll() {
+        isLoading = true
         loadChartData()
         loadAllTimeStats()
+        isLoading = false
     }
 
     func onRangeChanged() {

--- a/InputMetrics/InputMetrics/Views/KeyboardStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/KeyboardStatsView.swift
@@ -5,83 +5,90 @@ struct KeyboardStatsView: View {
     @State private var viewModel = KeyboardStatsViewModel()
 
     var body: some View {
-        VStack(spacing: 20) {
-            // Date navigation
-            HStack {
-                Button(action: { viewModel.previousDay() }) {
-                    Image(systemName: "chevron.left")
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Previous day")
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                VStack(spacing: 20) {
+                    // Date navigation
+                    HStack {
+                        Button(action: { viewModel.previousDay() }) {
+                            Image(systemName: "chevron.left")
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Previous day")
 
-                DatePicker("", selection: $viewModel.selectedDate, displayedComponents: .date)
-                    .labelsHidden()
-                    .onChange(of: viewModel.selectedDate) { _, _ in
-                        viewModel.loadAll()
+                        DatePicker("", selection: $viewModel.selectedDate, displayedComponents: .date)
+                            .labelsHidden()
+                            .onChange(of: viewModel.selectedDate) { _, _ in
+                                viewModel.loadAll()
+                            }
+
+                        Button(action: { viewModel.nextDay() }) {
+                            Image(systemName: "chevron.right")
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Next day")
+                        .disabled(Calendar.current.isDateInToday(viewModel.selectedDate))
+
+                        if !Calendar.current.isDateInToday(viewModel.selectedDate) {
+                            Button("Today") {
+                                viewModel.selectedDate = Date()
+                                viewModel.loadAll()
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.blue)
+                        }
                     }
+                    .padding(.horizontal)
 
-                Button(action: { viewModel.nextDay() }) {
-                    Image(systemName: "chevron.right")
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Next day")
-                .disabled(Calendar.current.isDateInToday(viewModel.selectedDate))
-
-                if !Calendar.current.isDateInToday(viewModel.selectedDate) {
-                    Button("Today") {
-                        viewModel.selectedDate = Date()
-                        viewModel.loadAll()
+                    // Time range selector
+                    HStack {
+                        Spacer()
+                        Picker("Range", selection: $viewModel.selectedRange) {
+                            Text("Week").tag(TimeRange.week)
+                            Text("Month").tag(TimeRange.month)
+                            Text("Year").tag(TimeRange.year)
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(width: 250)
+                        .onChange(of: viewModel.selectedRange) { _, _ in
+                            viewModel.onRangeChanged()
+                        }
                     }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.blue)
+                    .padding(.horizontal)
+
+                    // Chart
+                    ChartView(data: viewModel.chartData, range: viewModel.selectedRange, metric: .keystrokes)
+                        .frame(height: 250)
+                        .padding()
+
+                    // Keyboard heatmap
+                    KeyboardHeatmapView(entries: viewModel.keyboardEntries)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("Keyboard heatmap showing key usage frequency")
+                        .padding()
+
+                    // Top keys
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Top Keys Today:")
+                            .font(.headline)
+
+                        HStack(spacing: 12) {
+                            ForEach(viewModel.topKeys, id: \.id) { entry in
+                                Text("\(entry.name) (\(entry.count))")
+                                    .font(.caption)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 4)
+                                    .background(Color.blue.opacity(0.2))
+                                    .cornerRadius(4)
+                            }
+                        }
+                    }
+                    .padding()
                 }
             }
-            .padding(.horizontal)
-
-            // Time range selector
-            HStack {
-                Spacer()
-                Picker("Range", selection: $viewModel.selectedRange) {
-                    Text("Week").tag(TimeRange.week)
-                    Text("Month").tag(TimeRange.month)
-                    Text("Year").tag(TimeRange.year)
-                }
-                .pickerStyle(.segmented)
-                .frame(width: 250)
-                .onChange(of: viewModel.selectedRange) { _, _ in
-                    viewModel.onRangeChanged()
-                }
-            }
-            .padding(.horizontal)
-
-            // Chart
-            ChartView(data: viewModel.chartData, range: viewModel.selectedRange, metric: .keystrokes)
-                .frame(height: 250)
-                .padding()
-
-            // Keyboard heatmap
-            KeyboardHeatmapView(entries: viewModel.keyboardEntries)
-                .accessibilityElement(children: .ignore)
-                .accessibilityLabel("Keyboard heatmap showing key usage frequency")
-                .padding()
-
-            // Top keys
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Top Keys Today:")
-                    .font(.headline)
-
-                HStack(spacing: 12) {
-                    ForEach(viewModel.topKeys, id: \.id) { entry in
-                        Text("\(entry.name) (\(entry.count))")
-                            .font(.caption)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(Color.blue.opacity(0.2))
-                            .cornerRadius(4)
-                    }
-                }
-            }
-            .padding()
         }
         .onAppear {
             viewModel.loadAll()

--- a/InputMetrics/InputMetrics/Views/MouseStatsView.swift
+++ b/InputMetrics/InputMetrics/Views/MouseStatsView.swift
@@ -5,98 +5,105 @@ struct MouseStatsView: View {
     @State private var viewModel = MouseStatsViewModel()
 
     var body: some View {
-        VStack(spacing: 20) {
-            // Date navigation
-            HStack {
-                Button(action: { viewModel.previousDay() }) {
-                    Image(systemName: "chevron.left")
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Previous day")
-
-                DatePicker("", selection: $viewModel.selectedDate, displayedComponents: .date)
-                    .labelsHidden()
-                    .onChange(of: viewModel.selectedDate) { _, _ in
-                        viewModel.loadAll()
-                    }
-
-                Button(action: { viewModel.nextDay() }) {
-                    Image(systemName: "chevron.right")
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Next day")
-                .disabled(Calendar.current.isDateInToday(viewModel.selectedDate))
-
-                if !Calendar.current.isDateInToday(viewModel.selectedDate) {
-                    Button("Today") {
-                        viewModel.selectedDate = Date()
-                        viewModel.loadAll()
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.blue)
-                }
-            }
-            .padding(.horizontal)
-
-            // Time range selector
-            HStack {
-                Spacer()
-                Picker("Range", selection: $viewModel.selectedRange) {
-                    Text("Week").tag(TimeRange.week)
-                    Text("Month").tag(TimeRange.month)
-                    Text("Year").tag(TimeRange.year)
-                }
-                .pickerStyle(.segmented)
-                .frame(width: 250)
-                .onChange(of: viewModel.selectedRange) { _, _ in
-                    viewModel.onRangeChanged()
-                }
-            }
-            .padding(.horizontal)
-
-            // Chart
-            ChartView(data: viewModel.chartData, range: viewModel.selectedRange)
-                .frame(height: 250)
-                .padding()
-
-            // Stats and heatmap
-            HStack(alignment: .top, spacing: 20) {
-                // Heatmap placeholder
-                VStack {
-                    Text("Mouse Heatmap")
-                        .font(.headline)
-                    HeatmapView()
-                        .frame(width: 300, height: 300)
-                }
-
-                // All-time stats
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("All-Time Stats")
-                        .font(.headline)
-
-                    if let stats = viewModel.allTimeStats {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Distance: \(DistanceConverter.formatDistance(stats.mouseDistancePx))")
-                            Text("Clicks: \(stats.mouseClicksLeft + stats.mouseClicksRight + stats.mouseClicksMiddle)")
-                            Text("Scroll: \(viewModel.formatScrollDistance(vertical: stats.scrollDistanceVertical, horizontal: stats.scrollDistanceHorizontal))")
-                            Text("Keystrokes: \(stats.keystrokes)")
-
-                            Divider()
-
-                            Text("\u{1F30D} " + DistanceConverter.formatEarthComparison(stats.mouseDistancePx))
-                                .font(.caption)
-                            Text("\u{1F319} " + DistanceConverter.formatMoonComparison(stats.mouseDistancePx))
-                                .font(.caption)
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                VStack(spacing: 20) {
+                    // Date navigation
+                    HStack {
+                        Button(action: { viewModel.previousDay() }) {
+                            Image(systemName: "chevron.left")
                         }
-                    } else {
-                        Text("Start using your mouse and keyboard to see stats here")
-                            .foregroundStyle(.secondary)
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Previous day")
+
+                        DatePicker("", selection: $viewModel.selectedDate, displayedComponents: .date)
+                            .labelsHidden()
+                            .onChange(of: viewModel.selectedDate) { _, _ in
+                                viewModel.loadAll()
+                            }
+
+                        Button(action: { viewModel.nextDay() }) {
+                            Image(systemName: "chevron.right")
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Next day")
+                        .disabled(Calendar.current.isDateInToday(viewModel.selectedDate))
+
+                        if !Calendar.current.isDateInToday(viewModel.selectedDate) {
+                            Button("Today") {
+                                viewModel.selectedDate = Date()
+                                viewModel.loadAll()
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.blue)
+                        }
                     }
+                    .padding(.horizontal)
+
+                    // Time range selector
+                    HStack {
+                        Spacer()
+                        Picker("Range", selection: $viewModel.selectedRange) {
+                            Text("Week").tag(TimeRange.week)
+                            Text("Month").tag(TimeRange.month)
+                            Text("Year").tag(TimeRange.year)
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(width: 250)
+                        .onChange(of: viewModel.selectedRange) { _, _ in
+                            viewModel.onRangeChanged()
+                        }
+                    }
+                    .padding(.horizontal)
+
+                    // Chart
+                    ChartView(data: viewModel.chartData, range: viewModel.selectedRange)
+                        .frame(height: 250)
+                        .padding()
+
+                    // Stats and heatmap
+                    HStack(alignment: .top, spacing: 20) {
+                        // Heatmap placeholder
+                        VStack {
+                            Text("Mouse Heatmap")
+                                .font(.headline)
+                            HeatmapView()
+                                .frame(width: 300, height: 300)
+                        }
+
+                        // All-time stats
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("All-Time Stats")
+                                .font(.headline)
+
+                            if let stats = viewModel.allTimeStats {
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text("Distance: \(DistanceConverter.formatDistance(stats.mouseDistancePx))")
+                                    Text("Clicks: \(stats.mouseClicksLeft + stats.mouseClicksRight + stats.mouseClicksMiddle)")
+                                    Text("Scroll: \(viewModel.formatScrollDistance(vertical: stats.scrollDistanceVertical, horizontal: stats.scrollDistanceHorizontal))")
+                                    Text("Keystrokes: \(stats.keystrokes)")
+
+                                    Divider()
+
+                                    Text("\u{1F30D} " + DistanceConverter.formatEarthComparison(stats.mouseDistancePx))
+                                        .font(.caption)
+                                    Text("\u{1F319} " + DistanceConverter.formatMoonComparison(stats.mouseDistancePx))
+                                        .font(.caption)
+                                }
+                            } else {
+                                Text("Start using your mouse and keyboard to see stats here")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding()
                 }
-                .padding()
-                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .padding()
         }
         .onAppear {
             viewModel.loadAll()


### PR DESCRIPTION
## Summary
- Adds `isLoading` property to MouseStatsViewModel and KeyboardStatsViewModel
- MouseStatsView and KeyboardStatsView show `ProgressView()` while loading
- Existing content renders once loading completes

Closes #176

## Test plan
- [ ] Verify ProgressView appears briefly on view load
- [ ] Verify stats render correctly after loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)