### PR TITLE
perf: Cap speedSamples buffer size in MouseTracker

### DIFF
--- a/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
+++ b/InputMetrics/InputMetrics/Services/KeyboardTracker.swift
@@ -17,6 +17,7 @@ class KeyboardTracker {
         let modifierFlags: Int
     }
 
+    // Naturally bounded by unique key+modifier combinations (~100 keys)
     private var heatmapBuffer: [HeatmapKey: Int] = [:]
 
     private init() {

--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -29,7 +29,10 @@ class MouseTracker {
     private var scrollVertical: Double = 0
     private var scrollHorizontal: Double = 0
 
+    // Naturally bounded by grid size (50x50 per screen per date)
     private var heatmapBuffer: [HeatmapBucketKey: Int] = [:]
+
+    private let maxSpeedSamples = 500
 
     private var persistTimer: Timer?
     private let persistInterval: TimeInterval = 30.0
@@ -120,6 +123,9 @@ class MouseTracker {
             let elapsed = now.timeIntervalSince(lastTime)
             if elapsed > 0 && elapsed < 1.0 {
                 let speed = distance / elapsed
+                if speedSamples.count >= maxSpeedSamples {
+                    speedSamples.removeFirst()
+                }
                 speedSamples.append(speed)
                 peakMouseSpeed = max(peakMouseSpeed, speed)
             }


### PR DESCRIPTION
## Summary
- Caps `speedSamples` array at 500 entries to prevent unbounded growth
- Removes oldest entry when at capacity before appending
- Adds comments documenting natural bounds of heatmap buffers

Closes #177

## Test plan
- [ ] Verify mouse speed tracking still works correctly
- [ ] Verify memory usage stays stable during extended use

🤖 Generated with [Claude Code](https://claude.com/claude-code)