### PR TITLE
feat(i18n): Add Localizable.xcstrings string catalog

### DIFF
--- a/InputMetrics/InputMetrics/Localizable.xcstrings
+++ b/InputMetrics/InputMetrics/Localizable.xcstrings
@@ -1,0 +1,5 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {},
+  "version" : "1.0"
+}


### PR DESCRIPTION
## Summary
- Creates empty `Localizable.xcstrings` string catalog with English as source language
- Xcode will auto-populate the catalog with SwiftUI Text strings on build
- No code changes needed — SwiftUI already uses LocalizedStringKey by default

Closes #178

## Test plan
- [ ] Verify Xcode recognizes the string catalog
- [ ] Verify strings are extracted on build

🤖 Generated with [Claude Code](https://claude.com/claude-code)