### PR TITLE
chore(ci): Auto-set bundle version from git tag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
 
+      - name: Set version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" InputMetrics/InputMetrics/Info.plist
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" InputMetrics/InputMetrics/Info.plist
+
       - name: Import signing certificate
         env:
           CERTIFICATE_P12: ${{ secrets.DEVELOPER_ID_CERTIFICATE_P12 }}


### PR DESCRIPTION
## Summary
- Adds "Set version from tag" step to release workflow
- Extracts marketing version from git tag (strips `v` prefix)
- Sets build number from `git rev-list --count HEAD`
- Writes both to Info.plist via PlistBuddy before archive

Closes #181

## Test plan
- [ ] Verify release workflow sets correct version from tag
- [ ] Verify build number increments with commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)