### PR TITLE
ci: skip build for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Summary
- Add `paths-ignore: docs/**` to CI workflow triggers
- Docs-only pushes/PRs no longer waste macOS runner minutes on build+test

Closes #206

## Test plan
- [ ] Push a docs-only change → CI should not trigger
- [ ] Push a code change → CI should trigger normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)