### PR TITLE
fix(ci): Install provisioning profile for App Groups entitlement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,19 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_NAME" login.keychain-db
           rm certificate.p12
 
+      - name: Install provisioning profile
+        env:
+          PROVISIONING_PROFILE: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          echo "$PROVISIONING_PROFILE" | base64 --decode > profile.provisioningprofile
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          PROFILE_PLIST=$(security cms -D -i profile.provisioningprofile)
+          PROFILE_UUID=$(echo "$PROFILE_PLIST" | /usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin)
+          PROFILE_NAME=$(echo "$PROFILE_PLIST" | /usr/libexec/PlistBuddy -c "Print Name" /dev/stdin)
+          cp profile.provisioningprofile ~/Library/MobileDevice/Provisioning\ Profiles/"$PROFILE_UUID".provisioningprofile
+          echo "PROFILE_NAME=$PROFILE_NAME" >> "$GITHUB_ENV"
+          rm profile.provisioningprofile
+
       - name: Resolve package dependencies
         run: xcodebuild -resolvePackageDependencies -project InputMetrics.xcodeproj -scheme InputMetrics
 
@@ -57,7 +70,7 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Developer ID Application" \
             DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
-            PROVISIONING_PROFILE_SPECIFIER=""
+            PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME"
 
       - name: Export app
         run: |


### PR DESCRIPTION
## Summary
- Add provisioning profile installation step to release workflow
- Pass profile name via `PROVISIONING_PROFILE_SPECIFIER` to the archive command
- Required because the App Groups entitlement (added in #205) needs a provisioning profile even for Developer ID distribution

## Required setup
Add `PROVISIONING_PROFILE_BASE64` GitHub secret:
1. Create a **Developer ID** provisioning profile on developer.apple.com with the App Group entitlement
2. `base64 -i profile.provisioningprofile | pbcopy`
3. Add as repo secret `PROVISIONING_PROFILE_BASE64`

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)