### PR TITLE
chore: Update all URLs from InputStats to InputMetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lightweight macOS menu bar app that tracks mouse movements, clicks, and keyboa
 
 ## Download
 
-[**Download the latest release**](https://github.com/owieth/InputStats/releases/latest) — signed and notarized for macOS.
+[**Download the latest release**](https://github.com/owieth/InputMetrics/releases/latest) — signed and notarized for macOS.
 
 ### Installation
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
   <title>InputMetrics — macOS Input Tracker</title>
   <link rel="icon" type="image/png" href="app-icon.png">
   <meta name="description" content="InputMetrics is a free, open-source macOS menu bar app that tracks keyboard and mouse usage with heatmaps, charts, and detailed statistics. All data stays on your Mac.">
-  <link rel="canonical" href="https://owieth.github.io/InputStats/">
+  <link rel="canonical" href="https://owieth.github.io/InputMetrics/">
   <meta name="theme-color" content="#0071e3" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#4da3ff" media="(prefers-color-scheme: dark)">
 
@@ -14,8 +14,8 @@
   <meta property="og:title" content="InputMetrics — macOS Input Tracker">
   <meta property="og:description" content="Free, open-source macOS menu bar app that tracks keyboard and mouse usage with heatmaps, charts, and statistics. 100% local, zero network requests.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://owieth.github.io/InputStats/">
-  <meta property="og:image" content="https://owieth.github.io/InputStats/app-icon.png">
+  <meta property="og:url" content="https://owieth.github.io/InputMetrics/">
+  <meta property="og:image" content="https://owieth.github.io/InputMetrics/app-icon.png">
   <meta property="og:image:width" content="256">
   <meta property="og:image:height" content="256">
   <meta property="og:locale" content="en_US">
@@ -25,7 +25,7 @@
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="InputMetrics — macOS Input Tracker">
   <meta name="twitter:description" content="Free, open-source macOS menu bar app that tracks keyboard and mouse usage with heatmaps, charts, and statistics. 100% local.">
-  <meta name="twitter:image" content="https://owieth.github.io/InputStats/app-icon.png">
+  <meta name="twitter:image" content="https://owieth.github.io/InputMetrics/app-icon.png">
 
   <style>
     :root {
@@ -224,13 +224,13 @@
     "@type": "SoftwareApplication",
     "name": "InputMetrics",
     "description": "A lightweight macOS menu bar app that tracks keyboard and mouse usage with heatmaps, charts, and detailed statistics.",
-    "url": "https://owieth.github.io/InputStats/",
+    "url": "https://owieth.github.io/InputMetrics/",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "macOS 15+",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "downloadUrl": "https://github.com/owieth/InputStats/releases/latest",
+    "downloadUrl": "https://github.com/owieth/InputMetrics/releases/latest",
     "author": { "@type": "Person", "name": "Olivier Winkler", "url": "https://github.com/owieth" },
-    "image": "https://owieth.github.io/InputStats/app-icon.png"
+    "image": "https://owieth.github.io/InputMetrics/app-icon.png"
   }
   </script>
 </head>
@@ -245,7 +245,7 @@
       <p>A lightweight macOS menu bar app that tracks your keyboard and mouse usage with beautiful charts, heatmaps, and detailed statistics. Entirely private, entirely local.</p>
       <span class="badge">macOS 15+ &middot; Free &middot; Open Source</span>
       <br>
-      <a class="download-btn" href="https://github.com/owieth/InputStats/releases/latest">Download Latest Release</a>
+      <a class="download-btn" href="https://github.com/owieth/InputMetrics/releases/latest">Download Latest Release</a>
     </div>
 
     <!-- Installation -->
@@ -428,14 +428,14 @@
       <p>If this policy changes, the updated version will be posted on this page with a new date.</p>
 
       <h3>Contact</h3>
-      <p>Questions about this policy? Open an issue on <a href="https://github.com/owieth/InputStats/issues">GitHub</a>.</p>
+      <p>Questions about this policy? Open an issue on <a href="https://github.com/owieth/InputMetrics/issues">GitHub</a>.</p>
     </section>
 
   </main>
 
   <footer>
     <div class="container">
-      <p>&copy; <script>document.write(new Date().getFullYear());</script> Olivier Winkler. <a href="https://github.com/owieth/InputStats">View on GitHub</a></p>
+      <p>&copy; <script>document.write(new Date().getFullYear());</script> Olivier Winkler. <a href="https://github.com/owieth/InputMetrics">View on GitHub</a></p>
     </div>
   </footer>
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://owieth.github.io/InputStats/sitemap.xml
+Sitemap: https://owieth.github.io/InputMetrics/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://owieth.github.io/InputStats/</loc>
+    <loc>https://owieth.github.io/InputMetrics/</loc>
     <lastmod>2026-03-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>


### PR DESCRIPTION
## Summary
Update all references from the old repo name `InputStats` to `InputMetrics`:
- README.md download link
- GitHub Pages: canonical URL, Open Graph, Twitter Card, structured data, footer, contact links
- sitemap.xml and robots.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)