### PR TITLE
fix(entitlements): add missing app-groups entitlement to main app target

### DIFF
--- a/InputMetrics/InputMetrics/InputMetrics.entitlements
+++ b/InputMetrics/InputMetrics/InputMetrics.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.inputmetrics.shared</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
The main app was missing the `com.apple.security.application-groups` entitlement required to access the shared App Group container. macOS enforces this strictly at login time, causing the app to crash with "SQLite error 23: authorization denied" when launched via SMAppService on startup.

## Changes
- Add `com.apple.security.application-groups` with `group.com.inputmetrics.shared` to `InputMetrics.entitlements`

## Additional Notes
The widget target already had this entitlement correctly declared. No code changes are needed — `DatabaseManager` and `WidgetDataProvider` already use the correct group ID.

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)