### PR TITLE
fix(menu-bar): add real-time data reloads and fix broken features

### DIFF
--- a/InputMetrics/InputMetrics/Services/EventMonitor.swift
+++ b/InputMetrics/InputMetrics/Services/EventMonitor.swift
@@ -167,6 +167,10 @@ class EventMonitor {
         (firstActiveAt, lastActiveAt)
     }
 
+    func getAppUsageSnapshot() -> [String: (name: String, keystrokes: Int, clicks: Int)] {
+        appBuffer
+    }
+
     func getAndResetActiveSeconds() -> TimeInterval {
         let seconds = activeSeconds
         activeSeconds = 0

--- a/InputMetrics/InputMetrics/Services/MouseTracker.swift
+++ b/InputMetrics/InputMetrics/Services/MouseTracker.swift
@@ -242,6 +242,10 @@ class MouseTracker {
         return (accumulatedDistance, leftClicks, rightClicks, middleClicks, scrollVertical, scrollHorizontal)
     }
 
+    func getHeatmapSnapshot() -> [HeatmapBucketKey: Int] {
+        heatmapBuffer
+    }
+
     private func bucketForPoint(_ point: CGPoint) -> (x: Int, y: Int) {
         guard let cache = screenCache else { return (0, 0) }
 

--- a/InputMetrics/InputMetrics/ViewModels/MenuBarViewModel.swift
+++ b/InputMetrics/InputMetrics/ViewModels/MenuBarViewModel.swift
@@ -46,6 +46,10 @@ final class MenuBarViewModel {
         Array(keyboardEntries.sorted { $0.count > $1.count }.prefix(5))
     }
 
+    var hasHeatmapData: Bool {
+        heatmapData.flatMap { $0 }.contains { $0 > 0 }
+    }
+
     func loadAll() {
         updateStats()
         loadChartData()
@@ -203,6 +207,11 @@ final class MenuBarViewModel {
             grid[entry.bucketY][entry.bucketX] += entry.clickCount
         }
 
+        for (key, count) in MouseTracker.shared.getHeatmapSnapshot() {
+            guard key.bucketX >= 0 && key.bucketY >= 0 && key.bucketX < 50 && key.bucketY < 50 else { continue }
+            grid[key.bucketY][key.bucketX] += count
+        }
+
         heatmapData = grid
     }
 
@@ -218,7 +227,25 @@ final class MenuBarViewModel {
 
     func loadAppUsage() {
         let today = todayString()
-        appUsageEntries = DatabaseManager.shared.getAppUsage(date: today)
+        var entries = DatabaseManager.shared.getAppUsage(date: today)
+
+        for (bundleId, live) in EventMonitor.shared.getAppUsageSnapshot() {
+            if let idx = entries.firstIndex(where: { $0.bundleId == bundleId }) {
+                entries[idx].keystrokes += live.keystrokes
+                entries[idx].mouseClicks += live.clicks
+            } else {
+                entries.append(AppUsageEntry(
+                    date: today,
+                    bundleId: bundleId,
+                    appName: live.name,
+                    keystrokes: live.keystrokes,
+                    mouseClicks: live.clicks,
+                    activeSeconds: 0
+                ))
+            }
+        }
+
+        appUsageEntries = entries.sorted { $0.keystrokes > $1.keystrokes }
     }
 
     func chartDistance(_ pixels: Double, unit: DistanceUnit) -> Double {

--- a/InputMetrics/InputMetrics/Views/MenuBarView.swift
+++ b/InputMetrics/InputMetrics/Views/MenuBarView.swift
@@ -8,6 +8,7 @@ struct MenuBarView: View {
     @State private var hoveredMouseLabel: String?
     @State private var hoveredKeyboardLabel: String?
     @State private var showKeyboardWarning = false
+    @State private var dataRefreshTick = 0
 
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
@@ -193,6 +194,14 @@ struct MenuBarView: View {
             viewModel.refreshAllTimeTotalsIfNeeded()
             viewModel.updateAllTimeStats()
             updateKeyboardWarning()
+            viewModel.loadChartData()
+            dataRefreshTick += 1
+            if dataRefreshTick % 10 == 0 {
+                viewModel.loadHeatmapData()
+                viewModel.loadKeyboardData()
+                viewModel.loadHourlySummaries()
+                viewModel.loadAppUsage()
+            }
         }
         .onAppear {
             viewModel.loadAll()
@@ -374,7 +383,7 @@ struct MenuBarView: View {
             // Mouse Heatmap
             VStack(alignment: .leading, spacing: 8) {
                 DisclosureGroup("Mouse Heatmap") {
-                    if !viewModel.heatmapData.isEmpty {
+                    if viewModel.hasHeatmapData {
                         HeatmapCanvas(data: viewModel.heatmapData)
                             .accessibilityElement(children: .ignore)
                             .accessibilityLabel("Mouse click heatmap showing click distribution")


### PR DESCRIPTION
## Summary

The menu bar popover's 1-second timer only refreshed live stat counters but never reloaded data from the database or in-memory buffers. This caused the week overview charts to be static, and the mouse heatmap, keyboard heatmap, hourly breakdown, and app usage sections to stay empty or broken after the initial load.

## Changes

- **`MenuBarView`** — call `loadChartData()` every second in the timer so charts reflect live mouse/keyboard activity; call `loadHeatmapData`, `loadKeyboardData`, `loadHourlySummaries`, and `loadAppUsage` every 10 seconds to keep those sections current
- **`MenuBarView`** — fix mouse heatmap empty-state guard: replace `!heatmapData.isEmpty` with `hasHeatmapData` so the all-transparent canvas is not rendered when no clicks have been recorded yet
- **`MenuBarViewModel`** — add `hasHeatmapData` computed property (true when any grid cell has a non-zero count)
- **`MenuBarViewModel`** — `loadHeatmapData()` now merges the live in-memory `heatmapBuffer` from `MouseTracker` on top of DB data, so clicks appear before the 30-second persist fires
- **`MenuBarViewModel`** — `loadAppUsage()` now merges the live `appBuffer` from `EventMonitor` into DB entries, so app usage appears immediately instead of waiting up to 60 seconds
- **`MouseTracker`** — expose `getHeatmapSnapshot()` to provide a read-only view of the in-memory heatmap buffer
- **`EventMonitor`** — expose `getAppUsageSnapshot()` to provide a read-only view of the in-memory app usage buffer

## Additional Notes

`loadChartData()` already merged live `MouseTracker`/`KeyboardTracker` stats before this fix — it just wasn't being called from the timer. The other reload calls are throttled to every 10 seconds to avoid unnecessary DB reads on every tick.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)