### PR TITLE
fix(ci): skip exportArchive, copy signed app directly from xcarchive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,10 @@ jobs:
             -archivePath build/InputMetrics.xcarchive \
             OTHER_CODE_SIGN_FLAGS="--deep --timestamp --options runtime"
 
-      - name: Export app
+      - name: Extract app from archive
         run: |
-          xcodebuild -exportArchive \
-            -archivePath build/InputMetrics.xcarchive \
-            -exportPath build/export \
-            -exportOptionsPlist ExportOptions.plist
+          mkdir -p build/export
+          cp -R build/InputMetrics.xcarchive/Products/Applications/InputMetrics.app build/export/InputMetrics.app
 
       - name: Notarize app
         env:

--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -5,6 +5,6 @@
     <key>method</key>
     <string>developer-id</string>
     <key>signingStyle</key>
-    <string>automatic</string>
+    <string>manual</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

`xcodebuild -exportArchive` kept failing regardless of `signingStyle`:
- With `manual`: required provisioning profiles for every nested Sparkle bundle (`Updater.app`, `Downloader.xpc`, `Installer.xpc`)
- With `automatic`: tried to look up profiles from the Apple Developer portal, which isn't available in CI

## Fix

Skip `xcodebuild -exportArchive` entirely. The app is already correctly signed by `xcodebuild archive` with `OTHER_CODE_SIGN_FLAGS="--deep --timestamp --options runtime"` which recursively signs all nested Sparkle binaries. Copy the signed `.app` directly from the xcarchive and pass it straight to notarization.

```
build/InputMetrics.xcarchive/Products/Applications/InputMetrics.app → build/export/InputMetrics.app
```

## Test plan

- [ ] Trigger a release and verify export + notarization succeeds
- [ ] Verify DMG mounts and app launches without Gatekeeper warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)